### PR TITLE
Test if dataset can be linked (see #9550)

### DIFF
--- a/omero/util_scripts/Dataset_To_Plate.py
+++ b/omero/util_scripts/Dataset_To_Plate.py
@@ -160,7 +160,7 @@ def datasets_to_plates(conn, scriptParams):
     IDs = [ds.getId() for ds in datasets if ds.canLink()]
     if len(IDs) != len(datasets):
         permIDs = [str(ds.getId()) for ds in datasets if not ds.canLink()]
-        message += "You don't have permission to re-link images within dataset: %s." % ",".join(permIDs)
+        message += "You do not have the permissions to add the images from the dataset(s): %s." % ",".join(permIDs)
     if not IDs:
         return None, message
 


### PR DESCRIPTION
- Add an additional level of datasets IDs filtering based on link permissions.
- Return informative error message if no valid dataset is found
