### PR TITLE
Point URLs at new doc locations

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -417,7 +417,7 @@ def runScript():
      
     client = scripts.client('Batch_Image_Export.py', """Save multiple images as jpegs or pngs in a zip
 file available for download as a batch export. 
-See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/running-scripts/running-util-scripts/""", 
+See http://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-util-scripts.html""",
 
     scripts.String("Data_Type", optional=False, grouping="1",
         description="The data you want to work with.", values=dataTypes, default="Image"),

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -509,7 +509,7 @@ def runAsScript():
     
     client = scripts.client('Movie_Figure.py', """Export a figure of a movie, showing a row of frames for each chosen image. 
 NB: OMERO.insight client provides a nicer UI for this script under 'Publishing Options'
-See https://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/exporting-figures""",
+See https://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-export-figures.html""",
 
     # provide 'Data_Type' and 'IDs' parameters so that Insight auto-populates with currently selected images.
     scripts.String("Data_Type", optional=False, grouping="01",

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -673,7 +673,7 @@ def runAsScript():
     oColours = wrap(OVERLAY_COLOURS.keys())
     
     client = scripts.client('Movie_ROI_Figure.py', """Create a figure of movie frames from ROI region of image.
-See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/exporting-figures""",
+See http://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-export-figures.html""",
 
     scripts.String("Data_Type", optional=False, grouping="01",
         description="The data you want to work with.", values=dataTypes, default="Image"),

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -738,7 +738,7 @@ def runAsScript():
     
     client = scripts.client('ROI_Split_Figure.py', """Create a figure of an ROI region as separate zoomed split-channel panels.
 NB: OMERO.insight client provides a nicer UI for this script under 'Publishing Options'
-See https://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/exporting-figures""",
+See http://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-export-figures.html""",
 
     # provide 'Data_Type' and 'IDs' parameters so that Insight auto-populates with currently selected images.
     scripts.String("Data_Type", optional=False, grouping="01",

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -627,7 +627,7 @@ def runAsScript():
      
     client = scripts.client('Split_View_Figure.py', """Create a figure of split-view images.
 NB: OMERO.insight client provides a nicer UI for this script under 'Publishing Options'
-See https://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/exporting-figures
+See http://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-export-figures.html
 """,
 
     # provide 'Data_Type' and 'IDs' parameters so that Insight auto-populates with currently selected images.

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -310,7 +310,7 @@ def runAsScript():
     
     client = scripts.client('Thumbnail_Figure.py', """Export a figure of thumbnails, optionally sorted by tag.
 NB: OMERO.insight client provides a nicer UI for this script under 'Publishing Options'
-See https://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/exporting-figures""",
+See http://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-export-figures.html""",
 
         scripts.String("Data_Type", optional=False, grouping="1",
             description="The data you want to work with.", values=dataTypes, default="Dataset"),

--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -487,7 +487,7 @@ def runAsScript():
     
     client = scripts.client('Combine_Images.py', """Combine several single-plane images (or Z-stacks) into one with 
 greater Z, C, T dimensions.
-See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/running-util-scripts""", 
+See http://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-util-scripts.html""",
     
     scripts.String("Data_Type", optional=False, grouping="1",
         description="Use all the images in specified 'Datasets' or choose individual 'Images'.", values=dataTypes, default="Image"),

--- a/omero/util_scripts/Dataset_To_Plate.py
+++ b/omero/util_scripts/Dataset_To_Plate.py
@@ -241,7 +241,7 @@ def runAsScript():
     client = scripts.client('Dataset_To_Plate.py', """Take a Dataset of Images and put them in a new Plate,
 arranging them into rows or columns as desired.
 Optionally add the Plate to a new or existing Screen.
-See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/running-util-scripts""",
+See http://www.openmicroscopy.org/site/support/omero4/users/client-tutorials/insight/insight-util-scripts.html""",
 
     scripts.String("Data_Type", optional=False, grouping="1",
         description="Choose source of images (only Dataset supported)", values=dataTypes, default="Dataset"),


### PR DESCRIPTION
URLs in scripts.git were still point at the old documentation. It might be possible to solve these with re-directs.

@sbesson, @wmoore, @jburel - do these look like the right locations?
