### PR TITLE
Combine imgs 9747

### DIFF
--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -232,13 +232,13 @@ def assignImagesByRegex(parameterMap, imageIds, queryService, sourceZ, idNameMap
             print "Image ID: %s Name: %s is Z: %s C: %s T: %s channelName: %s" % (iId, name, theZ, theC, theT, cName)
             imageMap[(theZ,theC,theT)] = (iId, 0)   # every plane comes from z=0 
     
-    print "tStart:", tStart, "zStart:", zStart, "sizeT", sizeT, "sizeZ", sizeZ
+    print "assignImagesByRegex tStart:", tStart, "zStart:", zStart, "maxT+1:", sizeT, "maxZ+1:", sizeZ
     
     # if indexes were 1-based (or higher), need to shift indexes accordingly. 
     if tStart > 0 or zStart > 0:
         sizeT = sizeT-tStart
         sizeZ = sizeZ-zStart
-        print "sizeT", sizeT, "sizeZ", sizeZ
+        print "   sizeT:", sizeT, "sizeZ:", sizeZ
         iMap = {}
         for key, value in imageMap.items():
             z, c, t = key
@@ -281,7 +281,7 @@ def makeSingleImage(services, parameterMap, imageIds, dataset, colourMap):
     rawFileStore = services["rawFileStore"]
     containerService = services["containerService"]
     
-    print "imageIds", len(imageIds)
+    print "makeSingleImage: imageId count:", len(imageIds)
     
     # Filter images by name if user has specified filter. 
     idNameMap = None
@@ -292,7 +292,6 @@ def makeSingleImage(services, parameterMap, imageIds, dataset, colourMap):
             idNameMap = getImageNames(queryService, imageIds)
             imageIds = [i for i in imageIds if idNameMap[i].find(filterString) > -1]
             
-    print "imageIds", len(imageIds)
     imageId = imageIds[0]
     
     # get pixels, with pixelsType, from the first image
@@ -401,7 +400,8 @@ def combineImages(conn, parameterMap):
             colour = col.getValue()
             if colour in COLOURS:
                 colourMap[c] = COLOURS[colour]
-                
+    print "colourMap", colourMap
+
     # Get images or datasets
     message =""
     objects, logMessage = scriptUtil.getObjects(conn, parameterMap)


### PR DESCRIPTION
Fix channel colors, channel naming/order and improved some print statements.

To test:
- Need a number of appropriately named images (I need to look for these...)
- Run Combine_Images script, choosing different colours for each channel
- Check that channels are the correct colour and channel names are alphabetically ordered.
