### PR TITLE
Batch_Image_Export handles OME-TIFF better. See #8791

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -383,16 +383,22 @@ def batchImageExport(conn, scriptParams):
 
     # zip everything up (unless we've only got a single ome-tiff)
     if format == 'OME-TIFF' and len(os.listdir(exp_dir)) == 1:
+        ometiffIds = [t.id for t in parent.listAnnotations(ns=omero.constants.namespaces.NSOMETIFF)]
+        print "Deleting OLD ome-tiffs: %s" % ometiffIds
+        conn.deleteObjects("Annotation", ometiffIds)
         export_file = os.path.join(folder_name, os.listdir(exp_dir)[0])
+        namespace = omero.constants.namespaces.NSOMETIFF
+        outputDisplayName = "OME-TIFF"
         mimetype = 'image/tiff'
     else:
         export_file = "%s.zip" % folder_name
         compress(export_file, folder_name)
         mimetype='application/zip'
+        outputDisplayName = "Batch export zip"
+        namespace = omero.constants.namespaces.NSCREATED+"/omero/export_scripts/Batch_Image_Export"
 
-    namespace = omero.constants.namespaces.NSCREATED+"/omero/export_scripts/Batch_Image_Export"
     fileAnnotation, annMessage = script_utils.createLinkFileAnnotation(conn, export_file, parent, 
-        output="Batch export zip", ns=namespace, mimetype=mimetype)
+        output=outputDisplayName, ns=namespace, mimetype=mimetype)
     message += annMessage
     return fileAnnotation, message
 


### PR DESCRIPTION
This uses the new omero.constants.NSOMETIFF namespace so that the webclient can allow users to download existing OME-TIFF files (instead of generating new ones). 
It will delete any existing OME-TIFF files on the image, so there is only the latest one remaining.

Also improves the messages to users.

To test, run the script, either via the new OME-TIFF export button on https://github.com/openmicroscopy/openmicroscopy/pull/417 or via Batch Image Export script (with a single image). 

Then repeat. Only the newer OME-TIFF file should remain attached to the Image.
