### PR TITLE
Fix 'dataType' typo in thumbnail_figure. See #9986

### DIFF
--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -219,7 +219,7 @@ def makeThumbnailFigure(conn, scriptParams):
     # Get parent
     parent = None
     if "Parent_ID" in scriptParams and len(scriptParams["IDs"]) > 1:
-        if dataType == "Image":
+        if scriptParams["Data_Type"] == "Image":
             parent = conn.getObject("Dataset", scriptParams["Parent_ID"])
         else:
             parent = conn.getObject("Project", scriptParams["Parent_ID"])


### PR DESCRIPTION
Simple typo fix.

To test, select a number of images, run Thumbnail_Figure from the 'publishing options' menu in Insight. 
Should get a Figure generated. See https://github.com/openmicroscopy/openmicroscopy/pull/518 for related fixes in Insight. 
