### PR TITLE
OME-TIFF Big Images 10761

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -349,6 +349,11 @@ def batchImageExport(conn, scriptParams):
     if format == 'OME-TIFF':
         for img in images:
             log("Exporting image as OME-TIFF: %s" % img.getName())
+            if img._prepareRE().requiresPixelsPyramid():
+                log(  "  ** Can't export a 'Big' image to OME-TIFF. **")
+                if len(images) == 1:
+                    return None, "Can't export a 'Big' image to OME-TIFF."
+                continue
             saveAsOmeTiff(conn, img, folder_name)
 
     else:
@@ -387,6 +392,8 @@ def batchImageExport(conn, scriptParams):
         finally:
             logFile.close()
 
+    if len(os.listdir(exp_dir)) == 0:
+        return None, "No files exported. See 'info' for more details" 
     # zip everything up (unless we've only got a single ome-tiff)
     if format == 'OME-TIFF' and len(os.listdir(exp_dir)) == 1:
         ometiffIds = [t.id for t in parent.listAnnotations(ns=omero.constants.namespaces.NSOMETIFF)]


### PR DESCRIPTION
If you try to Batch_Image_Export a Big Image with format: OME-TIFF, you will get a message that says "Can't export a 'Big' image to OME-TIFF".

To test:
- In web, click the download menu in the right panel of a Big image, choose OME-TIFF then 'Create' in the dialog. The activities panel will show "Can't export a 'Big' image to OME-TIFF".
- The same can be seen in Insight (or web) by running the Batch_Image_Export script with a Big image. If multiple images are chosen, only the Big Images will be ignored and a zip will be created for the others, so the message will be "OME-TIFF created and attached to..."
