### PR TITLE
Don't allow jpeg export of Big images

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -349,11 +349,11 @@ def batchImageExport(conn, scriptParams):
     for img in images:
         if img._prepareRE().requiresPixelsPyramid():
             log(  "  ** Can't export a 'Big' image to %s. **" % format)
-                if len(images) == 1:
-                    return None, "Can't export a 'Big' image to %s." % format
-                continue
+            if len(images) == 1:
+                return None, "Can't export a 'Big' image to %s." % format
+            continue
         else:
-            log("Exporting image as %s: %s" % (format, img.getName())
+            log("Exporting image as %s: %s" % (format, img.getName()))
 
         if format == 'OME-TIFF':
             saveAsOmeTiff(conn, img, folder_name)


### PR DESCRIPTION
From http://trac.openmicroscopy.org.uk/ome/ticket/10841
For Big images, if we try to run Batch_Image_Export with any format, we should return a "Not supported" message.

This is simply an extension of https://github.com/ome/scripts/pull/30 to apply to ALL formats (not just OME-TIFF).

NB: haven't tested this locally because of issues with https://trac.openmicroscopy.org.uk/ome/ticket/10970

To test:
- Try to run Batch_Image_Export.py with any Big image, choosing format as JPEG, then again with OME-TIFF.
- Should get the same message with each.
