### PR TITLE
Script paths to basename 11464

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -255,6 +255,7 @@ def batchImageExport(conn, scriptParams):
     dataType = scriptParams["Data_Type"]
     ids = scriptParams["IDs"]
     folder_name = scriptParams["Folder_Name"]
+    folder_name = os.path.basename(folder_name)
     format = scriptParams["Format"]
     projectZ = "Choose_Z_Section" in scriptParams and scriptParams["Choose_Z_Section"] == 'Max projection'
     

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -540,6 +540,7 @@ def writeMovie(commandArgs, conn):
     movieName = "Movie"
     if "Movie_Name" in commandArgs:
         movieName = commandArgs["Movie_Name"]
+        movieName = os.path.basename(movieName)
     if not movieName.endswith(".%s" % ext):
         movieName = "%s.%s" % (movieName, ext)
         

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -481,7 +481,7 @@ def movieFigure(conn, commandArgs):
     output = "movieFigure"
     if "Figure_Name" in commandArgs:
         output = str(commandArgs["Figure_Name"])
-        
+        output = os.path.basename(output)
     if format == 'PNG':
         output = output + ".png"
         figure.save(output, "PNG")

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -633,7 +633,7 @@ def roiFigure(conn, commandArgs):
     output = "movieROIFigure"
     if "Figure_Name" in commandArgs:
         output = str(commandArgs["Figure_Name"])
-        
+        output = os.path.basename(output)
     if format == 'PNG':
         output = output + ".png"
         fig.save(output, "PNG")

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -703,7 +703,7 @@ def roiFigure(conn, commandArgs):
     output = "roiFigure"
     if "Figure_Name" in commandArgs:
         output = str(commandArgs["Figure_Name"])
-        
+        output = os.path.basename(output)
     if format == 'PNG':
         output = output + ".png"
         fig.save(output, "PNG")

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -598,6 +598,7 @@ def splitViewFigure(conn, scriptParams):
     figLegend = "\n".join(logStrings)
 
     output = scriptParams["Figure_Name"]
+    output = os.path.basename(output)
     format = scriptParams["Format"]
     if format == "PNG":
         output = output + ".png"

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -44,6 +44,7 @@ import omero.util.script_utils as scriptUtil
 from omero.rtypes import *
 import omero.util.imageUtil as imgUtil
 from datetime import date
+import os
 
 try:
     from PIL import Image, ImageDraw # see ticket:2597
@@ -385,6 +386,7 @@ def makeThumbnailFigure(conn, scriptParams):
     
     format = scriptParams["Format"]
     output = scriptParams["Figure_Name"]
+    output = os.path.basename(output)
         
     if format == 'PNG':
         output = output + ".png"


### PR DESCRIPTION
This fixes https://trac.openmicroscopy.org.uk/ome/ticket/11464 where several scripts use a filename coming from a script parameter without checking whether the filename is actually a path.

For each of the scripts in this PR, we validate that the file name is only a name using os.path.basename().

To test:
- Run E.g. Movie Figure script in Insight, using an image that is named like: path/to/the/image.dv
  The path will be removed and the figure should become named "image.jpg".
- You can try this with a few of the different scripts (include Batch_Image_Export), but probably not worth doing all of them. I've already tested them all and they all have exactly the same commit applied.
