### PR TITLE
Use param file names for naming original files

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -548,21 +548,22 @@ def writeMovie(commandArgs, conn):
     framesPerSec = 2
     if "FPS" in commandArgs:
         framesPerSec = commandArgs["FPS"]
-    buildAVI(mw, mh, filelist, framesPerSec, movieName, format)
+    output = "localfile.%s" % ext
+    buildAVI(mw, mh, filelist, framesPerSec, output, format)
     figLegend = "\n".join(logLines)
     mimetype = formatMimetypes[format]
 
-    if not os.path.exists(movieName):
-        print "mencoder Failed to create movie file: %s" % movieName
-        return None, "Failed to create movie file: %s" % movieName
+    if not os.path.exists(output):
+        print "mencoder Failed to create movie file: %s" % output
+        return None, "Failed to create movie file: %s" % output
     if not commandArgs["Do_Link"]:
-        originalFile = scriptUtil.createFile(updateService, movieName, mimetype, movieName);
-        scriptUtil.uploadFile(rawFileStore, originalFile, movieName)
+        originalFile = scriptUtil.createFile(updateService, output, mimetype, movieName);
+        scriptUtil.uploadFile(rawFileStore, originalFile, output)
         return originalFile, message
     
     namespace = omero.constants.namespaces.NSCREATED+"/omero/export_scripts/Make_Movie"
-    fileAnnotation, annMessage = scriptUtil.createLinkFileAnnotation(conn, movieName, omeroImage,
-        output="Movie", ns=namespace, mimetype=mimetype)
+    fileAnnotation, annMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
+        output="Movie", ns=namespace, mimetype=mimetype, origFilePathAndName=movieName)
     message += annMessage
     return fileAnnotation._obj, message
 

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -478,26 +478,30 @@ def movieFigure(conn, commandArgs):
     
     format = commandArgs["Format"]
             
-    output = "movieFigure"
+    figureName = "movieFigure"
     if "Figure_Name" in commandArgs:
-        output = str(commandArgs["Figure_Name"])
-        output = os.path.basename(output)
+        figureName = str(commandArgs["Figure_Name"])
+        figureName = os.path.basename(output)
+    output = "localfile"
     if format == 'PNG':
         output = output + ".png"
-        figure.save(output, "PNG")
+        figureName = figureName + ".png"
+        fig.save(output, "PNG")
         mimetype = "image/png"
     elif format == 'TIFF':
         output = output + ".tiff"
-        figure.save(output, "TIFF")
+        figureName = figureName + ".tiff"
+        fig.save(output, "TIFF")
         mimetype = "image/tiff"
     else:
         output = output + ".jpg"
-        figure.save(output)
+        figureName = figureName + ".jpg"
+        fig.save(output)
         mimetype = "image/jpeg"
     
     namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Movie_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie figure", mimetype=mimetype, ns=namespace, desc=figLegend)
+    output="Movie figure", mimetype=mimetype, ns=namespace, desc=figLegend, origFilePathAndName=figureName)
     message += faMessage
     
     return fileAnnotation, message

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -630,20 +630,24 @@ def roiFigure(conn, commandArgs):
     
     format = commandArgs["Format"]
             
-    output = "movieROIFigure"
+    figureName = "movieROIFigure"
     if "Figure_Name" in commandArgs:
-        output = str(commandArgs["Figure_Name"])
-        output = os.path.basename(output)
+        figureName = commandArgs["Figure_Name"]
+        figureName = os.path.basename(figureName)
+    output = "localfile"
     if format == 'PNG':
         output = output + ".png"
+        figureName = figureName + ".png"
         fig.save(output, "PNG")
         mimetype = "image/png"
     elif format == 'TIFF':
         output = output + ".tiff"
+        figureName = figureName + ".tiff"
         fig.save(output, "TIFF")
         mimetype = "image/tiff"
     else:
         output = output + ".jpg"
+        figureName = figureName + ".jpg"
         fig.save(output)
         mimetype = "image/jpeg"
     
@@ -652,7 +656,7 @@ def roiFigure(conn, commandArgs):
     # Returns the id of the originalFileLink child. (ID object, not value)
     namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Movie_ROI_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie ROI figure", mimetype=mimetype, ns=namespace, desc=figLegend)
+    output="Movie ROI figure", mimetype=mimetype, ns=namespace, desc=figLegend, origFilePathAndName=figureName)
     message += faMessage
     
     return fileAnnotation, message

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -700,20 +700,24 @@ def roiFigure(conn, commandArgs):
     
     format = commandArgs["Format"]
             
-    output = "roiFigure"
+    figureName = "roiFigure"
     if "Figure_Name" in commandArgs:
-        output = str(commandArgs["Figure_Name"])
-        output = os.path.basename(output)
+        figureName = commandArgs["Figure_Name"]
+        figureName = os.path.basename(figureName)
+    output = "localfile"
     if format == 'PNG':
         output = output + ".png"
+        figureName = figureName + ".png"
         fig.save(output, "PNG")
         mimetype = "image/png"
     elif format == 'TIFF':
         output = output + ".tiff"
+        figureName = figureName + ".tiff"
         fig.save(output, "TIFF")
         mimetype = "image/tiff"
     else:
         output = output + ".jpg"
+        figureName = figureName + ".jpg"
         fig.save(output)
         mimetype = "image/jpeg"
     
@@ -722,7 +726,7 @@ def roiFigure(conn, commandArgs):
     # Returns the id of the originalFileLink child. (ID object, not value)
     namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/ROI_Split_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="ROI Split figure", mimetype=mimetype, ns=namespace, desc=figLegend)
+        output="ROI Split figure", mimetype=mimetype, ns=namespace, desc=figLegend, origFilePathAndName=figureName)
     message += faMessage
     
     return fileAnnotation, message

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -597,19 +597,23 @@ def splitViewFigure(conn, scriptParams):
 
     figLegend = "\n".join(logStrings)
 
-    output = scriptParams["Figure_Name"]
-    output = os.path.basename(output)
+    figureName = scriptParams["Figure_Name"]
+    figureName = os.path.basename(figureName)
+    output = "localfile"
     format = scriptParams["Format"]
-    if format == "PNG":
+    if format == 'PNG':
         output = output + ".png"
+        figureName = figureName + ".png"
         fig.save(output, "PNG")
         mimetype = "image/png"
     elif format == 'TIFF':
         output = output + ".tiff"
+        figureName = figureName + ".tiff"
         fig.save(output, "TIFF")
         mimetype = "image/tiff"
     else:
         output = output + ".jpg"
+        figureName = figureName + ".jpg"
         fig.save(output)
         mimetype = "image/jpeg"
 
@@ -617,7 +621,7 @@ def splitViewFigure(conn, scriptParams):
     # figLegend as the fileAnnotation description.
     namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Split_View_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="Split view figure", mimetype=mimetype, ns=namespace, desc=figLegend)
+        output="Split view figure", mimetype=mimetype, ns=namespace, desc=figLegend, origFilePathAndName=figureName)
     message += faMessage
     
     return fileAnnotation, message

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -385,25 +385,29 @@ def makeThumbnailFigure(conn, scriptParams):
     figLegend = "\n".join(logLines)
     
     format = scriptParams["Format"]
-    output = scriptParams["Figure_Name"]
-    output = os.path.basename(output)
+    figureName = scriptParams["Figure_Name"]
+    figureName = os.path.basename(figureName)
+    output = "localfile"
         
     if format == 'PNG':
         output = output + ".png"
+        figureName = figureName + ".png"
         figure.save(output, "PNG")
         mimetype = "image/png"
     elif format == 'TIFF':
         output = output + ".tiff"
+        figureName = figureName + ".tiff"
         figure.save(output, "TIFF")
         mimetype = "image/tiff"
     else:
         output = output + ".jpg"
+        figureName = figureName + ".jpg"
         figure.save(output)
         mimetype = "image/jpeg"
 
     namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Thumbnail_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, parent,
-        output="Thumbnail figure", mimetype=mimetype, ns=namespace, desc=figLegend)
+        output="Thumbnail figure", mimetype=mimetype, ns=namespace, desc=figLegend, origFilePathAndName=figureName)
     message += faMessage
 
     return fileAnnotation, message


### PR DESCRIPTION
As suggested by @joshmoore in https://github.com/ome/scripts/pull/39, the figure scripts (and Make_Movie script) don't use the user-supplied file name to write local files, but only as the name of the uploaded original file.

This is safer, since it's only used in the DB, not in any paths etc.

To test:
- Run Make_Movie script, and one of the others (same change to all) choosing various strings for Figure or Movie name. Check name after creation.
