### PR TITLE
Combine images param unwrap 11473

### DIFF
--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -454,7 +454,7 @@ def combineImages(conn, parameterMap):
     objects, logMessage = scriptUtil.getObjects(conn, parameterMap)
     message += logMessage
     if not objects:
-        print "No Objects Found"
+        print message
         return None, message
 
     # get the images IDs from list (in order) or dataset (sorted by name)


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11473.

To test, choose 2 (or more) single-channel, single time-point images, Run util script > Combine Images.
De-select the "Auto Define Dimensions", select "Manually Define Dimensions" and choose Dimension 1: Channels.

Optionally choose colours and or names for the channels.
Run the script.
Check that all the input images got combined into a new image.
