### PR TITLE
Prevent ZeroDivisionError on sizeT=1

### DIFF
--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -91,6 +91,10 @@ def getLineData(pixels, x1, y1, x2, y2, lineW=2, theZ=0, theC=0, theT=0):
     lineX = x2-x1
     lineY = y2-y1
 
+    if lineY == 0:
+        raise Exception(
+            "%s-%s for divisor. Cannot continue",
+            y2, y1)
     rads = math.atan(float(lineX)/lineY)
 
     # How much extra Height do we need, top and bottom?


### PR DESCRIPTION
Found in openmicroscopy/openmicroscopy#1822.

@pwalczysko : we can retest by re-running the build or dropping this into a server
@will-moore : is this the behavior you would expect?
