### PR TITLE
1822 script param fix dev 4 4

### DIFF
--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -348,7 +348,8 @@ def processImages(conn, scriptParams):
 
     for image in images:
         if image.getSizeT() == 1:
-            print "Image: %s is not a movie (sizeT = 1) - Can't create Kymograph" % image.getId()
+            print "Image: %s is not a movie (sizeT = 1)"\
+                " - Can't create Kymograph" % image.getId()
             continue
         newImages = []      # kymographs derived from the current image.
         cNames = []


### PR DESCRIPTION
This PR replaces @joshmoore's PR of the same name #55.

Ignores images where sizeT = 1.

To test, draw a line on an image where sizeT = 1 (not a movie).
Run the kymograph script with this image.

--rebased-from #56
