### PR TITLE
Exclude datasets containing images linked to wells (rebased onto develop)

### DIFF
--- a/omero/util_scripts/Dataset_To_Plate.py
+++ b/omero/util_scripts/Dataset_To_Plate.py
@@ -38,7 +38,7 @@ from omero.gateway import BlitzGateway
 import omero.util.script_utils as script_utils
 import omero
 
-from omero.rtypes import rint, rlong, rstring, robject, rlist, unwrap
+from omero.rtypes import rint, rlong, rstring, robject, unwrap
 
 
 def addImageToPlate(conn, image, plateId, column, row, removeFrom=None):


### PR DESCRIPTION
This is the same as gh-57 but rebased onto develop.

---

This PR fixes https://trac.openmicroscopy.org.uk/ome/ticket/11848

For each found dataset, a query is submitted to find all contained images linked to wells and exclude this dataset. The number of excluded datasets is returned to the client output and the ID of the excluded datasets is stored in the script log.

```
$ bin/omero script launch 183 IDs=-2,2,51 Remove_From_Dataset=False
Using session 9a8aa5af-d148-46e8-9d07-bdc74f37e37b (root@localhost:4064). Idle timeout: 10.0 min. Current group: system
Job 142 ready
Waiting....
Callback received: FINISHED

    *** start stdout (id=186)***
    * {'Row_Names': 'letter', 'Remove_From_Dataset': False, 'Column_Names': 'number', 'Data_Type': 'Dataset', 'First_Axis_Count': 12L, 'IDs': [-2L, 2L, 51L], 'First_Axis': 'column'}
    * Dataset 2 contains images linked to wells.
    * Dataset 51 contains images linked to wells.
    * 
    *** end stdout ***


    *** out parameters ***
    * Message=Found 2 out of 3 dataset(s). Excluded 2 out of 2 dataset(s). 
    ***  done ***
```

To test this PR:
- try to run the `Dataset To Plate` multiple times on the same dataset with the  `Remove from Dataset` option turned off
- try to run `Dataset To Plate` on a mixture of freshly import datasets and datasets already converted to plate using the `Dataset To Plate` script with the `Remove from Dataset` option turned off
-  try to run `Dataset To Plate` on a dataset containing a mixture of freshly imported images and images linked to wells (e.g. run `Dataset To Plate` with the `Remove from Dataset` option turned off on a dataset and cut and paste a subset of its images to another dataset)

/cc @will-moore, @chris-allan 
