### PR TITLE
Use fromstring() instead of fromarray() #11912

### DIFF
--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -63,7 +63,9 @@ def numpyToImage(plane):
         # int32 is handled by PIL (not uint32 etc). TODO: support floats
         convArray = zeros(plane.shape, dtype=int32)
         convArray += plane
-        return Image.fromarray(convArray)
+        # Trac#11912 PIL < 1.1.7 fromarray doesn't handle 16 bit images
+        return Image.fromstring(
+            'I', (plane.shape[1], plane.shape[0]), convArray)
     return Image.fromarray(plane)
 
 

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -60,7 +60,9 @@ def numpyToImage(plane):
         # int32 is handled by PIL (not uint32 etc). TODO: support floats
         convArray = zeros(plane.shape, dtype=int32)
         convArray += plane
-        return Image.fromarray(convArray)
+        # Trac#11912 PIL < 1.1.7 fromarray doesn't handle 16 bit images
+        return Image.fromstring(
+            'I', (plane.shape[1], plane.shape[0]), convArray)
     return Image.fromarray(plane)
 
 


### PR DESCRIPTION
The Kymograph script should work with 8/16-bit images using PIL <= 1.1.6 (default on Centos 6). Also made the same change to Plot_Profile.
