### PR TITLE
Drop --use-mirrors from .travis.yml (rebased onto develop)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
   - "2.6"
 virtualenv:
   system_site_packages: true
-install: pip install flake8 --use-mirrors
+install: pip install flake8
 script: flake8 -v .


### PR DESCRIPTION
This is the same as gh-64 but rebased onto develop.

---
