### PR TITLE
Kymograph_Analysis creates single csv. See #11909 (rebased onto dev_5_0)

### DIFF
--- a/omero/analysis_scripts/Kymograph_Analysis.py
+++ b/omero/analysis_scripts/Kymograph_Analysis.py
@@ -152,7 +152,6 @@ def processImages(conn, scriptParams):
             tableString = "\nAnalysing Image ID: %s" % image.getId()
             tableString += "\nsecsPerPixelY: %s" % secsPerPixelY
             tableString += '\nmicronsPerPixelX: %s' % micronsPerPixelX
-            # tableString += "\nmicronsPerSec: %s" % micronsPerSec
             tableString += "\n"
             tableString += colNames
             tableString += tableData


### PR DESCRIPTION
This is the same as gh-60 but rebased onto dev_5_0.

---

See https://trac.openmicroscopy.org.uk/ome/ticket/11909

To test, draw diagonal ROI lines on 2 or more images (any single-Z & single-T images will do - don't have to be kymographs). Select the images and run Analysis Script -> Kymograph Analysis (in web or Insight). 
Should generate a single csv file that contains data from each line in each image.

--no-rebase
