### PR TITLE
Allow passing extra channel rendering options to Make_Movie script

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -73,6 +73,7 @@ from omero.constants.namespaces import NSCREATED
 from omero.constants.metadata import NSMOVIE
 
 from cStringIO import StringIO
+from types import StringTypes
 
 try:
     from PIL import Image, ImageDraw  # see ticket:2597
@@ -287,7 +288,8 @@ def validChannels(set, sizeC):
     if(len(set) == 0):
         return False
     for val in set:
-        val = int(val.split('|')[0].split('$')[0])
+        if isinstance(val, StringTypes):
+            val = int(val.split('|')[0].split('$')[0])
         if(val < 0 or val > sizeC):
             return False
     return True


### PR DESCRIPTION
(see #12037)

Added new argument to script; ChannelsExtended. The accepted format to allow for passing channel window range and color, with the format 'idx|min:max' having both '|min:max' and '' optional, but when both are present order must be respected.
ex: ChannelsExtended=2|0:250,3|50:100

If both Channels and ChannelsExtended are passed, the latter takes precedence.

This is the 5.0 counterpart to https://github.com/ome/scripts/pull/67
