### PR TITLE
Allow passing extra channel rendering options to Make_Movie script (rebased onto develop)

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -67,7 +67,7 @@ import re
 import numpy
 import omero.util.pixelstypetopython as pixelstypetopython
 from struct import unpack
-from omero.rtypes import wrap, rstring, rlong, rint, robject
+from omero.rtypes import wrap, rstring, rlong, robject
 from omero.gateway import BlitzGateway
 from omero.constants.namespaces import NSCREATED
 from omero.constants.metadata import NSMOVIE
@@ -508,7 +508,8 @@ def writeMovie(commandArgs, conn):
         cWindows = []
         cColours = []
         for c in commandArgs["Channels"]:
-            m = re.match('^(?P<i>\d+)(\|(?P<ws>\d+)\:(?P<we>\d+))?(\$(?P<c>.+))?$', c)
+            m = re.match('^(?P<i>\d+)(\|(?P<ws>\d+)'+\
+                         '\:(?P<we>\d+))?(\$(?P<c>.+))?$', c)
             if m is not None:
                 cRange.append(int(m.group('i'))-1)
                 cWindows.append([float(m.group('ws')), float(m.group('we'))])
@@ -524,7 +525,9 @@ def writeMovie(commandArgs, conn):
             commandArgs["Show_Time"] = False
 
     frameNo = 1
-    omeroImage.setActiveChannels(map(lambda x: x+1, cRange), cWindows, cColours)
+    omeroImage.setActiveChannels(map(lambda x: x+1, cRange),
+                                 cWindows,
+                                 cColours)
     renderingEngine = omeroImage._re
 
     overlayColour = (255, 255, 255)

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -508,7 +508,7 @@ def writeMovie(commandArgs, conn):
         cWindows = []
         cColours = []
         for c in commandArgs["Channels"]:
-            m = re.match('^(?P<i>\d+)(\|(?P<ws>\d+)'+\
+            m = re.match('^(?P<i>\d+)(\|(?P<ws>\d+)' +
                          '\:(?P<we>\d+))?(\$(?P<c>.+))?$', c)
             if m is not None:
                 cRange.append(int(m.group('i'))-1)

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -73,6 +73,7 @@ from omero.constants.namespaces import NSCREATED
 from omero.constants.metadata import NSMOVIE
 
 from cStringIO import StringIO
+from types import StringTypes
 
 try:
     from PIL import Image, ImageDraw  # see ticket:2597
@@ -287,7 +288,8 @@ def validChannels(set, sizeC):
     if(len(set) == 0):
         return False
     for val in set:
-        val = int(val.split('|')[0].split('$')[0])
+        if isinstance(val, StringTypes):
+            val = int(val.split('|')[0].split('$')[0])
         if(val < 0 or val > sizeC):
             return False
     return True

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -287,6 +287,7 @@ def validChannels(set, sizeC):
     if(len(set) == 0):
         return False
     for val in set:
+        val = int(val.split('|')[0].split('$')[0])
         if(val < 0 or val > sizeC):
             return False
     return True
@@ -499,9 +500,19 @@ def writeMovie(commandArgs, conn):
         commandArgs["Scalebar"] = 0
 
     cRange = range(0, sizeC)
+    cWindows = None
+    cColours = None
     if "Channels" in commandArgs and \
             validChannels(commandArgs["Channels"], sizeC):
-        cRange = commandArgs["Channels"]
+        cRange = []
+        cWindows = []
+        cColours = []
+        for c in commandArgs["Channels"]:
+            m = re.match('^(?P<i>\d+)(\|(?P<ws>\d+)\:(?P<we>\d+))?(\$(?P<c>.+))?$', c)
+            if m is not None:
+                cRange.append(int(m.group('i'))-1)
+                cWindows.append([float(m.group('ws')), float(m.group('we'))])
+                cColours.append(m.group('c'))
 
     tzList = calculateRanges(sizeZ, sizeT, commandArgs)
 
@@ -513,7 +524,7 @@ def writeMovie(commandArgs, conn):
             commandArgs["Show_Time"] = False
 
     frameNo = 1
-    omeroImage.setActiveChannels(map(lambda x: x+1, cRange))
+    omeroImage.setActiveChannels(map(lambda x: x+1, cRange), cWindows, cColours)
     renderingEngine = omeroImage._re
 
     overlayColour = (255, 255, 255)
@@ -689,7 +700,7 @@ def runAsScript():
         scripts.List(
             "Channels",
             description="The selected channels",
-            grouping="5").ofType(rint(0)),
+            grouping="5").ofType(rstring('')),
 
         scripts.Bool(
             "Show_Time",

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -67,7 +67,7 @@ import re
 import numpy
 import omero.util.pixelstypetopython as pixelstypetopython
 from struct import unpack
-from omero.rtypes import wrap, rstring, rlong, robject
+from omero.rtypes import wrap, rstring, rint, rlong, robject
 from omero.gateway import BlitzGateway
 from omero.constants.namespaces import NSCREATED
 from omero.constants.metadata import NSMOVIE
@@ -502,18 +502,21 @@ def writeMovie(commandArgs, conn):
     cRange = range(0, sizeC)
     cWindows = None
     cColours = None
-    if "Channels" in commandArgs and \
-            validChannels(commandArgs["Channels"], sizeC):
+    if "ChannelsExtended" in commandArgs and \
+            validChannels(commandArgs["ChannelsExtended"], sizeC):
         cRange = []
         cWindows = []
         cColours = []
-        for c in commandArgs["Channels"]:
+        for c in commandArgs["ChannelsExtended"]:
             m = re.match('^(?P<i>\d+)(\|(?P<ws>\d+)' +
                          '\:(?P<we>\d+))?(\$(?P<c>.+))?$', c)
             if m is not None:
                 cRange.append(int(m.group('i'))-1)
                 cWindows.append([float(m.group('ws')), float(m.group('we'))])
                 cColours.append(m.group('c'))
+    elif "Channels" in commandArgs and \
+            validChannels(commandArgs["Channels"], sizeC):
+        cRange = commandArgs["Channels"]
 
     tzList = calculateRanges(sizeZ, sizeT, commandArgs)
 
@@ -703,7 +706,13 @@ def runAsScript():
         scripts.List(
             "Channels",
             description="The selected channels",
-            grouping="5").ofType(rstring('')),
+            grouping="5.1").ofType(rint(0)),
+
+        scripts.List(
+            "ChannelsExtended",
+            description="The selected channels, with optional range"
+            " and colour. Takes precendence over Channels.",
+            grouping="5.2").ofType(rstring('')),
 
         scripts.Bool(
             "Show_Time",


### PR DESCRIPTION
This is the same as gh-70 but rebased onto develop.

---

(see #12037)

Added new argument to script; ChannelsExtended. The accepted format to allow for passing channel window range and color, with the format 'idx|min:max' having both '|min:max' and '' optional, but when both are present order must be respected.
ex: ChannelsExtended=2|0:250,3|50:100

If both Channels and ChannelsExtended are passed, the latter takes precedence.

This is the 5.0 counterpart to https://github.com/ome/scripts/pull/67
