### PR TITLE
Fix 'No permissions' error in Make_Movie.py. See #12227

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -470,7 +470,6 @@ def writeMovie(commandArgs, conn):
 
     message = ""
 
-    conn.SERVICE_OPTS.setOmeroGroup('-1')
     session = conn.c.sf
     updateService = session.getUpdateService()
     rawFileStore = session.createRawFileStore()


### PR DESCRIPTION
This fixes https://trac.openmicroscopy.org.uk/ome/ticket/12227

To test, try running Make_Movie script (this will have to be locally since mencoder isn't installed on trout https://trello.com/c/0thKrlX5/449-mencoder-on-trout). The movie should be uploaded to OMERO as a file annotation and returned.
