### PR TITLE
Make movie format time 12254

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -59,6 +59,7 @@ params:
 
 import omero.scripts as scripts
 import omero.util.script_utils as scriptUtil
+import omero.util.figureUtil as figureUtil
 import omero
 import omero.min  # Constants etc.
 import os
@@ -233,7 +234,8 @@ def addPlaneInfo(z, t, pixels, image, colour):
 
 
 def addTimePoints(time, pixels, image, colour):
-    """ Displays the time-points. """
+    """ Displays the time-points as hrs:mins:secs """
+    time = figureUtil.formatTime(time, "HOURS_MINS_SECS")
     image_w, image_h = image.size
     draw = ImageDraw.Draw(image)
     textY = image_h-45


### PR DESCRIPTION
Timestamps in Make_Movie.py are formatted as hr:min:sec instead of seconds.
See https://trac.openmicroscopy.org.uk/ome/ticket/12254.

@cneves Does this affect your use of this script?
