### PR TITLE
Travis fix (rebased onto dev_4_4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
   - "2.6"
+  - "2.7"
+  - "2.7_with_system_site_packages"
 install: pip install flake8
 script: flake8 -v .


### PR DESCRIPTION
This is the same as gh-78 but rebased onto dev_4_4.

---

This should restore the Travis build as `system_site_packages: true` is not supported for Python 2.6 anymore apparently.
