### PR TITLE
Update batch image export tutorial link (rebased onto dev_5_0)

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -497,8 +497,7 @@ def runScript():
         'Batch_Image_Export.py',
         """Save multiple images as jpegs or pngs in a zip file available for \
 download as a batch export.
-See http://www.openmicroscopy.org/site/support/omero4/\
-users/client-tutorials/insight/insight-util-scripts.html""",
+See http://help.openmicroscopy.org/scripts.html""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="1",


### PR DESCRIPTION
This is the same as gh-85 but rebased onto dev_5_0.

---

client tutorials in the main docs have been replaced by the 'help' guides for some time but this script was still pointing at a link which doesn't exist anymore.

Will need rebasing to dev_5_0.
