### PR TITLE
Image from roi

### DIFF
--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -284,8 +284,9 @@ def processImage(conn, imageId, parameterMap):
                 projectLink.child = omero.model.DatasetI(
                     dataset.id.val, False)
                 updateService.saveAndReturnObject(projectLink)
-        #apply the rendering settings of the source image to all generated images.
-        conn.getRenderingSettingsService().applySettingsToSet(pixels.getId(), 'Image', iIds)
+        # Apply rnd settings of the source image to new images.
+        svc = conn.getRenderingSettingsService()
+        svc.applySettingsToSet(pixels.getId(), 'Image', iIds)
         return images, dataset, link
 
 

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -191,7 +191,7 @@ def processImage(conn, imageId, parameterMap):
             link = omero.model.DatasetImageLinkI()
             link.parent = omero.model.DatasetI(parentDataset.getId(), False)
             link.child = omero.model.ImageI(image.getId(), False)
-            conn.getUpdateService().saveAndReturnObject(link)
+            updateService.saveAndReturnObject(link)
         else:
             link = None
 

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -284,6 +284,8 @@ def processImage(conn, imageId, parameterMap):
                 projectLink.child = omero.model.DatasetI(
                     dataset.id.val, False)
                 updateService.saveAndReturnObject(projectLink)
+        #apply the rendering settings of the source image to all generated images.
+        conn.getRenderingSettingsService().applySettingsToSet(pixels.getId(), 'Image', iIds)
         return images, dataset, link
 
 


### PR DESCRIPTION
This PR applies the rendering settings of the source image to the generated images. The problem was highlighted during the workshop in Montpellier

To test:
- Select an image.
- Modify the rendering settings e.g. change color so you can remember the changes. Save the rendering settings.
- Draw a rectangular roi on the image. Save.
- Run the `Images_From_ROIs` on the image.
- A new image with the rendering settings of the source image should be created.
