### PR TITLE
Avoid division by 0 in Plot Profile. (rebased onto develop)

### DIFF
--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -88,7 +88,7 @@ def getLineData(pixels, x1, y1, x2, y2, lineW=2, theZ=0, theC=0, theT=0):
     sizeY = pixels.getSizeY()
 
     lineX = x2-x1
-    lineY = y2-y1
+    lineY = 1 if y2-y1 == 0 else y2-y1
 
     rads = math.atan(float(lineX) / lineY)
 


### PR DESCRIPTION
This is the same as gh-89 but rebased onto develop.

---

This PR fixes the situation in which a `ZeroDivisionError` is thrown when the ROI line is parallel to the X axis and hence the `y1` and `y2` values are equal, returning 0 in the subtraction.

The error returned was:

``` python
Traceback (most recent call last):
  File "./script", line 453, in <module>
    fileAnns, message = processImages(conn, scriptParams)
  File "./script", line 382, in processImages
    processLines(conn, scriptParams, image, lines, lineWidth, f)
  File "./script", line 264, in processLines
    lineWidth, theZ, theC, theT)
  File "./script", line 93, in getLineData
    rads = math.atan(float(lineX) / lineY)
ZeroDivisionError: float division
```

To test - check that the values returned from the script make sense.
/cc @will-moore
