### PR TITLE
Change figure script logging for null dates.

### DIFF
--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -427,7 +427,10 @@ def movieFigure(conn, commandArgs):
         tags = ", ".join(tagsList)
         pdString = ", ".join(["%s/%s" % pd for pd in pdList])
         log(" Image: %s  ID: %d" % (name, iId))
-        log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        if imageDate:
+            log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        else:
+            log("  Date: not set")
         log("  Tags: %s" % tags)
         log("  Project/Datasets: %s" % pdString)
 

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -561,7 +561,10 @@ def roiFigure(conn, commandArgs):
         tags = ", ".join(tagsList)
         pdString = ", ".join(["%s/%s" % pd for pd in pdList])
         log(" Image: %s  ID: %d" % (name, iId))
-        log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        if imageDate:
+            log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        else:
+            log("  Date: not set")
         log("  Tags: %s" % tags)
         log("  Project/Datasets: %s" % pdString)
 

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -634,7 +634,10 @@ def roiFigure(conn, commandArgs):
         tags = ", ".join(tagsList)
         pdString = ", ".join(["%s/%s" % pd for pd in pdList])
         log(" Image: %s  ID: %d" % (name, iId))
-        log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        if imageDate:
+            log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        else:
+            log("  Date: not set")
         log("  Tags: %s" % tags)
         log("  Project/Datasets: %s" % pdString)
 

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -559,7 +559,10 @@ def splitViewFigure(conn, scriptParams):
         tags = ", ".join(tagsList)
         pdString = ", ".join(["%s/%s" % pd for pd in pdList])
         log(" Image: %s  ID: %d" % (name, iId))
-        log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        if imageDate:
+            log("  Date: %s" % date.fromtimestamp(imageDate/1000))
+        else:
+            log("  Date: not set")
         log("  Tags: %s" % tags)
         log("  Project/Datasets: %s" % pdString)
 


### PR DESCRIPTION
Due to changes in https://github.com/openmicroscopy/openmicroscopy/pull/2847 the acquisition date can now be null. This caused these tests: http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-integration-python/199/testReport/test.integration.test_figureExportScripts/TestFigureExportScripts/ to fail. The failure is due to the four scripts logging the acquisition date. This PR changes that logging rather than removing it.

It's probably enough of a test if these four integration tests pass.

/cc @will-moore @mtbc 
