### PR TITLE
Movies saved with specified filename

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -644,8 +644,8 @@ def writeMovie(commandArgs, conn):
 
     namespace = NSCREATED + "/omero/export_scripts/Make_Movie"
     fileAnnotation, annMessage = scriptUtil.createLinkFileAnnotation(
-        conn, output, omeroImage, output="Movie", ns=namespace,
-        mimetype=mimetype)
+        conn, output, omeroImage, ns=namespace,
+        mimetype=mimetype, origFilePathAndName=movieName)
     message += annMessage
     return fileAnnotation._obj, message
 


### PR DESCRIPTION
Fixes naming of Movies created with Make_Movie script, as reported in https://github.com/openmicroscopy/openmicroscopy/pull/3282#issuecomment-67302122

Test in Insight and Web:
 - Movie will now be saved (as attachment to image) according to the file name specified in the script dialog.
 - NB: Insight and web still have different policies for the default name in the Make Movie dialog when handling images named with path/to/image.tiff