### PR TITLE
Movies saved with specified filename (rebased onto dev_5_0)

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -645,8 +645,8 @@ def writeMovie(commandArgs, conn):
 
     namespace = NSCREATED + "/omero/export_scripts/Make_Movie"
     fileAnnotation, annMessage = scriptUtil.createLinkFileAnnotation(
-        conn, output, omeroImage, output="Movie", ns=namespace,
-        mimetype=mimetype)
+        conn, output, omeroImage, ns=namespace,
+        mimetype=mimetype, origFilePathAndName=movieName)
     message += annMessage
     return fileAnnotation._obj, message
 


### PR DESCRIPTION

This is the same as gh-95 but rebased onto dev_5_0.

----

Fixes naming of Movies created with Make_Movie script, as reported in https://github.com/openmicroscopy/openmicroscopy/pull/3282#issuecomment-67302122

Test in Insight:
 - Movie will now be saved (as attachment to image) according to the file name specified in the script dialog.
 - NB: Insight and web still have different policies for the default name in the Make Movie dialog when handling images named with path/to/image.tiff

                