### PR TITLE
Big images

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -28,9 +28,6 @@ zip file for download.
 @author Will Moore
 <a href="mailto:will@lifesci.dundee.ac.uk">will@lifesci.dundee.ac.uk</a>
 @version 4.3
-<small>
-(<b>Internal version:</b> $Revision: $Date: $)
-</small>
 @since 3.0-Beta4.3
 """
 

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -394,8 +394,13 @@ def batchImageExport(conn, scriptParams):
 
     # do the saving to disk
 
-    for img in images:
+    ids = []
+    for img in images: 
         pixels = img.getPrimaryPixels()
+        if (pixels.getId().getValue() in ids)
+            continue
+        ids.append(pixels.getId().getValue())
+
         sizeX = pixels.getSizeX()
         sizeY = pixels.getSizeY()
         if sizeX*sizeY > size:

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -385,12 +385,8 @@ def batchImageExport(conn, scriptParams):
     except:
         pass
     # max size (default 12kx12k)
-    size = 144000000
-    try:
-        size = conn.getDownloadAsMaxSizeSetting()
-        size = int(size)
-    except:
-        pass
+    size = conn.getDownloadAsMaxSizeSetting()
+    size = int(size)
 
     ids = []
     # do the saving to disk

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -384,11 +384,22 @@ def batchImageExport(conn, scriptParams):
         os.mkdir(exp_dir)
     except:
         pass
+    # max size (default 12kx12k)
+    size = 144000000
+    try:
+        size = self.getConfigService().getConfigValue(
+            "omero.client.download_as.max_size")
+        size = int(size)
+    except:
+        pass
 
     # do the saving to disk
 
     for img in images:
-        if img._prepareRE().requiresPixelsPyramid():
+        pixels = image.getPrimaryPixels()
+        sizeX = pixels.getSizeX()
+        sizeY = pixels.getSizeY()
+        if sizeX*sizeY > size:
             log("  ** Can't export a 'Big' image to %s. **" % format)
             if len(images) == 1:
                 return None, "Can't export a 'Big' image to %s." % format

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -387,7 +387,7 @@ def batchImageExport(conn, scriptParams):
     # max size (default 12kx12k)
     size = 144000000
     try:
-        size = self.getConfigService().getConfigValue(
+        size = conn.getConfigService().getConfigValue(
             "omero.client.download_as.max_size")
         size = int(size)
     except:
@@ -396,7 +396,7 @@ def batchImageExport(conn, scriptParams):
     # do the saving to disk
 
     for img in images:
-        pixels = image.getPrimaryPixels()
+        pixels = img.getPrimaryPixels()
         sizeX = pixels.getSizeX()
         sizeY = pixels.getSizeY()
         if sizeX*sizeY > size:

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -387,8 +387,7 @@ def batchImageExport(conn, scriptParams):
     # max size (default 12kx12k)
     size = 144000000
     try:
-        size = conn.getConfigService().getConfigValue(
-            "omero.client.download_as.max_size")
+        size = conn.getDownloadAsMaxSizeSetting()
         size = int(size)
     except:
         pass

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -393,9 +393,9 @@ def batchImageExport(conn, scriptParams):
 
     for img in images:
         pixels = img.getPrimaryPixels()
-        if (pixels.getId().getValue() in ids):
+        if (pixels.getId() in ids):
             continue
-        ids.append(pixels.getId().getValue())
+        ids.append(pixels.getId())
         sizeX = pixels.getSizeX()
         sizeY = pixels.getSizeY()
         if sizeX*sizeY > size:

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -392,15 +392,14 @@ def batchImageExport(conn, scriptParams):
     except:
         pass
 
+    ids = []
     # do the saving to disk
 
-    ids = []
-    for img in images: 
+    for img in images:
         pixels = img.getPrimaryPixels()
-        if (pixels.getId().getValue() in ids)
+        if (pixels.getId().getValue() in ids):
             continue
         ids.append(pixels.getId().getValue())
-
         sizeX = pixels.getSizeX()
         sizeY = pixels.getSizeY()
         if sizeX*sizeY > size:


### PR DESCRIPTION
Use the new limit to export images as jpeg or png
To test:
- run the script on a large image. This can be done by using the export as jpeg from the right-hand panel.
