### PR TITLE
Populate metadata

### DIFF
--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -34,14 +34,14 @@ from omero.util.populate_roi import DownloadingOriginalFileProvider
 from omero.util.populate_metadata import ParsingContext
 
 
-def get_original_file(conn, object_type, plate_id, file_id):
+def get_original_file(conn, object_type, object_id, file_id):
     if object_type == "Plate":
-        omero_object = conn.getObject("Plate", int(plate_id))
+        omero_object = conn.getObject("Plate", int(object_id))
         if omero_object is None:
             sys.stderr.write("Error: Plate does not exist.\n")
             sys.exit(1)
     else:
-        omero_object = conn.getObject("Screen", int(plate_id))
+        omero_object = conn.getObject("Screen", int(object_id))
         if omero_object is None:
             sys.stderr.write("Error: Screen does not exist.\n")
             sys.exit(1)

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -77,7 +77,7 @@ def populate_metadata(client, conn, script_params):
 if __name__ == "__main__":
     dataTypes = [rstring('Plate'), rstring('Screen')]
     client = scripts.client(
-        'Poulate_Metadata.py',
+        'Populate_Metadata.py',
         """
         """,
         scripts.String(

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -79,6 +79,15 @@ if __name__ == "__main__":
     client = scripts.client(
         'Populate_Metadata.py',
         """
+        Attach a file in csv (comma separated values) format to a Screen or Plate.
+        Use a 'Well' column to specify wells via 'A1' etc.
+        Other columns contain values for each well. For example:
+
+        Well, Reagent, Volume
+        A1,   DMSO, 10 ul
+        A2,   Drug, 5 ul
+
+        Then select the Screen or Plate and run this script.
         """,
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -1,0 +1,105 @@
+# coding=utf-8
+'''
+-----------------------------------------------------------------------------
+  Copyright (C) 2014 Glencoe Software, Inc. All rights reserved.
+
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+------------------------------------------------------------------------------
+
+Populate metadata from CSV.
+'''
+
+import omero
+from omero.gateway import BlitzGateway
+from omero.rtypes import rstring
+import omero.scripts as scripts
+from omero.model import PlateI
+
+import sys
+
+from omero.util.populate_roi import DownloadingOriginalFileProvider
+from omero.util.populate_metadata import ParsingContext
+
+
+def get_original_file(conn, plateId, fileId):
+    plate = conn.getObject("Plate", int(plateId))
+    if plate is None:
+        sys.stderr.write("Error: Object does not exist.\n")
+        sys.exit(1)
+    for ann in plate.listAnnotations():
+        if isinstance(ann, omero.gateway.FileAnnotationWrapper):
+            print "File ID:", ann.getFile().getId(), ann.getFile().getName(),\
+                "Size:", ann.getFile().getSize()
+            if (ann.getFile().getId() == int(fileId)):
+                file = ann.getFile()._obj
+    if file is None:
+        sys.stderr.write("Error: File does not exist.\n")
+        sys.exit(1)
+    return file
+
+
+def populateMetadata(client, conn, scriptParams):
+    plateId = long(scriptParams["IDs"])
+    fileId = long(scriptParams["File_ID"])
+    original_file = get_original_file(conn, plateId, fileId)
+    provider = DownloadingOriginalFileProvider(conn)
+    fileHandle = provider.get_original_file_data(original_file)
+    plate = PlateI(long(plateId), False)
+    ctx = ParsingContext(client, plate, "")
+    ctx.parse_from_handle(fileHandle)
+    ctx.write_to_omero()
+
+
+if __name__ == "__main__":
+    dataTypes = [rstring('Plate')]
+    client = scripts.client(
+        'Poulate_Metadata.py',
+        """
+        """,
+        scripts.String(
+            "Data_Type", optional=False, grouping="1",
+            description="Choose source of images (only Plate supported)",
+            values=dataTypes, default="Plate"),
+
+        scripts.String(
+            "IDs", optional=False, grouping="2",
+            description="List of Image IDs to process."),
+
+        scripts.String(
+            "File_ID", optional=False, grouping="3", default='',
+            description="File ID containing metadata to populate."),
+
+        version="0.1",
+        authors=["Emil Rozbicki"],
+        institutions=["Glencoe Software Inc."],
+        contact="emil@glencoesoftware.com",
+    )
+
+    try:
+        # process the list of args above.
+        scriptParams = {}
+        for key in client.getInputKeys():
+            if client.getInput(key):
+                scriptParams[key] = client.getInput(key, unwrap=True)
+        print scriptParams
+
+        # wrap client to use the Blitz Gateway
+        conn = BlitzGateway(client_obj=client)
+        message = populateMetadata(client, conn, scriptParams)
+        client.setOutput("Message", rstring(message))
+
+    finally:
+        client.closeSession()

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -87,15 +87,15 @@ if __name__ == "__main__":
     client = scripts.client(
         'Populate_Metadata.py',
         """
-        Attach a file in csv (comma separated values) format to a Screen or Plate.
-        Use a 'Well' column to specify wells via 'A1' etc.
-        Other columns contain values for each well. For example:
+    Attach a file in csv (comma separated values) format to a Screen or Plate.
+    Use a 'Well' column to specify wells via 'A1' etc.
+    Other columns contain values for each well. For example:
 
-        Well, Reagent, Volume
-        A1,   DMSO, 10 ul
-        A2,   Drug, 5 ul
+    Well, Reagent, Volume
+    A1,   DMSO, 10 ul
+    A2,   Drug, 5 ul
 
-        Then select the Screen or Plate and run this script.
+    Then select the Screen or Plate and run this script.
         """,
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -96,7 +96,8 @@ if __name__ == "__main__":
     This script processes a csv file, attached to a Screen or Plate,
     converting it to an OMERO.table, with one row per Well.
     The table data can then be displayed in the OMERO clients.
-    For full details, see http://help.openmicroscopy.org/scripts.html
+    For full details, see
+    http://help.openmicroscopy.org/scripts.html#metadata
         """,
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -34,7 +34,7 @@ from omero.util.populate_roi import DownloadingOriginalFileProvider
 from omero.util.populate_metadata import ParsingContext
 
 
-def get_original_file(conn, object_type, object_id, file_id):
+def get_original_file(conn, object_type, object_id, fileAnn_id):
     if object_type == "Plate":
         omero_object = conn.getObject("Plate", int(object_id))
         if omero_object is None:
@@ -48,9 +48,9 @@ def get_original_file(conn, object_type, object_id, file_id):
     file = None
     for ann in omero_object.listAnnotations():
         if isinstance(ann, omero.gateway.FileAnnotationWrapper):
-            print "File ID:", ann.getFile().getId(), ann.getFile().getName(),\
+            print "FileAnnotation ID:", ann.getId(), ann.getFile().getName(),\
                 "Size:", ann.getFile().getSize()
-            if (ann.getFile().getId() == int(file_id)):
+            if (ann.getId() == int(fileAnn_id)):
                 file = ann.getFile()._obj
     if file is None:
         sys.stderr.write("Error: File does not exist.\n")
@@ -60,9 +60,9 @@ def get_original_file(conn, object_type, object_id, file_id):
 
 def populate_metadata(client, conn, script_params):
     object_id = long(script_params["IDs"])
-    file_id = long(script_params["File_ID"])
+    fileAnn_id = long(script_params["File_Annotation"])
     original_file = get_original_file(
-        conn, script_params["Data_Type"], object_id, file_id)
+        conn, script_params["Data_Type"], object_id, fileAnn_id)
     provider = DownloadingOriginalFileProvider(conn)
     file_handle = provider.get_original_file_data(original_file)
     if script_params["Data_Type"] == "Plate":
@@ -99,7 +99,7 @@ if __name__ == "__main__":
             description="List of Image IDs to process."),
 
         scripts.String(
-            "File_ID", optional=False, grouping="3", default='',
+            "File_Annotation", grouping="3", default='',
             description="File ID containing metadata to populate."),
 
         version="0.2",

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -34,13 +34,19 @@ from omero.util.populate_roi import DownloadingOriginalFileProvider
 from omero.util.populate_metadata import ParsingContext
 
 
-def get_original_file(conn, plate_id, file_id):
-    plate = conn.getObject("Plate", int(plate_id))
-    if plate is None:
-        sys.stderr.write("Error: Object does not exist.\n")
-        sys.exit(1)
+def get_original_file(conn, object_type, plate_id, file_id):
+    if object_type == "Plate":
+        omero_object = conn.getObject("Plate", int(plate_id))
+        if omero_object is None:
+            sys.stderr.write("Error: Plate does not exist.\n")
+            sys.exit(1)
+    else:
+        omero_object = conn.getObject("Screen", int(plate_id))
+        if omero_object is None:
+            sys.stderr.write("Error: Screen does not exist.\n")
+            sys.exit(1)
     file = None
-    for ann in plate.listAnnotations():
+    for ann in omero_object.listAnnotations():
         if isinstance(ann, omero.gateway.FileAnnotationWrapper):
             print "File ID:", ann.getFile().getId(), ann.getFile().getName(),\
                 "Size:", ann.getFile().getSize()
@@ -55,7 +61,8 @@ def get_original_file(conn, plate_id, file_id):
 def populate_metadata(client, conn, script_params):
     object_id = long(script_params["IDs"])
     file_id = long(script_params["File_ID"])
-    original_file = get_original_file(conn, object_id, file_id)
+    original_file = get_original_file(
+        conn, script_params["Data_Type"], object_id, file_id)
     provider = DownloadingOriginalFileProvider(conn)
     file_handle = provider.get_original_file_data(original_file)
     if script_params["Data_Type"] == "Plate":

--- a/util_scripts/Populate_Metadata.py
+++ b/util_scripts/Populate_Metadata.py
@@ -39,6 +39,7 @@ def get_original_file(conn, plateId, fileId):
     if plate is None:
         sys.stderr.write("Error: Object does not exist.\n")
         sys.exit(1)
+    file = None
     for ann in plate.listAnnotations():
         if isinstance(ann, omero.gateway.FileAnnotationWrapper):
             print "File ID:", ann.getFile().getId(), ann.getFile().getName(),\


### PR DESCRIPTION
As discussed https://github.com/openmicroscopy/openmicroscopy/pull/4455#issuecomment-179714477 Now that we support visualisation of bulk annotations in web (and Insight via tooltip) we want to make it easier for users to attach bulk annotations.

This PR copies the Glencoe script from https://github.com/glencoesoftware/omero-user-scripts/blob/master/util_scripts/Populate_Metadata.py and updates it a bit:
- Add (hopefully) useful description
- Use File_Annotation ID for picking files instead of File ID (web and Insight UI allow for picking File Ann)
- Make File_Annotation optional - If not set, we simply pick a .csv file from the Plate

To test, use Plate and csv files described https://github.com/openmicroscopy/ome-internal/blob/master/testing_scenarios/BulkAnnotations.txt
- Import Plate, attach test_plate.csv to it
- Select Plate and run script > Import Scripts > Populate_Metadata
- Read description. Makes sense?
- Run (don't need to choose File Annotation - will pick the csv automatically).
- Also, if multiple csv attached, you can pick the one you want from right panel and this will be used to populate the "File Annotation" parameter.
- When the script completes, selecting Wells should show the Bulk Annotation in right panel (as in https://github.com/openmicroscopy/openmicroscopy/pull/4446).

![screen shot 2016-02-04 at 15 27 54](https://cloud.githubusercontent.com/assets/900055/12819672/eab80682-cb53-11e5-8365-5787721037f5.png)

![screen shot 2016-02-04 at 15 26 12](https://cloud.githubusercontent.com/assets/900055/12819642/c67b7538-cb53-11e5-9ec1-19b10e638c60.png)
