### PR TITLE
Update figure & util script help links

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -513,7 +513,7 @@ def runScript():
         'Batch_Image_Export.py',
         """Save multiple images as JPEG, PNG, TIFF or OME-TIFF \
         in a zip file available for download as a batch export. \
-See http://help.openmicroscopy.org/scripts.html""",
+See http://help.openmicroscopy.org/export.html#batch""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -568,7 +568,7 @@ def runAsScript():
 chosen image.
 NB: OMERO.insight client provides a nicer UI for this script under \
 'Publishing Options'
-See http://help.openmicroscopy.org/scripts.html""",
+See http://help.openmicroscopy.org/publish.html#movies""",
 
         # provide 'Data_Type' and 'IDs' parameters so that Insight
         # auto-populates with currently selected images.

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -734,8 +734,7 @@ any ROI."""
 
     client = scripts.client(
         'Movie_ROI_Figure.py',
-        """Create a figure of movie frames from ROI region of image.
-See http://help.openmicroscopy.org/scripts.html""",
+        """Create a figure of movie frames from ROI region of image.""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="01",

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -837,7 +837,7 @@ any ROI."""
 panels.
 NB: OMERO.insight client provides a nicer UI for this script under \
 'Publishing Options'
-See http://help.openmicroscopy.org/scripts.html""",
+See http://help.openmicroscopy.org/publish.html#figures""",
 
         # provide 'Data_Type' and 'IDs' parameters so that Insight
         # auto-populates with currently selected images.

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -711,7 +711,7 @@ def runAsScript():
     client = scripts.client(
         'Split_View_Figure.py',
         """Create a figure of split-view images.
-See http://help.openmicroscopy.org/scripts.html""",
+See http://help.openmicroscopy.org/publish.html#figures""",
 
         # provide 'Data_Type' and 'IDs' parameters so that Insight
         # auto-populates with currently selected images.

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -481,7 +481,7 @@ def runAsScript():
     client = scripts.client(
         'Thumbnail_Figure.py',
         """Export a figure of thumbnails, optionally sorted by tag.
-See http://help.openmicroscopy.org/scripts.html""",
+See http://help.openmicroscopy.org/publish.html#figures""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/omero/util_scripts/Channel_Offsets.py
+++ b/omero/util_scripts/Channel_Offsets.py
@@ -273,7 +273,7 @@ def runAsScript():
         'Channel_Offsets.py',
         """Create new Images from existing images, applying an x, y and z \
 shift to each channel independently.
-See http://help.openmicroscopy.org/utility-scripts.html""",
+See http://help.openmicroscopy.org/scripts.html""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -543,7 +543,7 @@ def runAsScript():
         'Combine_Images.py',
         """Combine several single-plane images (or Z-stacks) into one with \
 greater Z, C, T dimensions.
-See http://help.openmicroscopy.org/utility-scripts.html""",
+See http://help.openmicroscopy.org/scripts.html""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/omero/util_scripts/Dataset_To_Plate.py
+++ b/omero/util_scripts/Dataset_To_Plate.py
@@ -284,7 +284,7 @@ def runAsScript():
         """Take a Dataset of Images and put them in a new Plate, \
 arranging them into rows or columns as desired.
 Optionally add the Plate to a new or existing Screen.
-See http://help.openmicroscopy.org/utility-scripts.html""",
+See http://help.openmicroscopy.org/scripts.html""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="1",


### PR DESCRIPTION
When the scripts sections of the Help were re-worked last year, we forgot to update the links for the figure scripts and now the utility scripts page is being renamed too.
