### PR TITLE
batch export big images

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -392,25 +392,33 @@ def batchImageExport(conn, scriptParams):
     # do the saving to disk
 
     for img in images:
+        log("Processing image: ID %s: %s" % (img.id, img.getName()))
         pixels = img.getPrimaryPixels()
         if (pixels.getId() in ids):
             continue
         ids.append(pixels.getId())
-        sizeX = pixels.getSizeX()
-        sizeY = pixels.getSizeY()
-        if sizeX*sizeY > size:
-            log("  ** Can't export a 'Big' image to %s. **" % format)
-            if len(images) == 1:
-                return None, "Can't export a 'Big' image to %s." % format
-            continue
-        else:
-            log("Exporting image as %s: %s" % (format, img.getName()))
 
         if format == 'OME-TIFF':
-            saveAsOmeTiff(conn, img, folder_name)
-        else:
             if img._prepareRE().requiresPixelsPyramid():
                 log("  ** Can't export a 'Big' image to OME-TIFF. **")
+                if len(images) == 1:
+                    return None, "Can't export a 'Big' image to %s." % format
+                continue
+            else:
+                saveAsOmeTiff(conn, img, folder_name)
+        else:
+            sizeX = pixels.getSizeX()
+            sizeY = pixels.getSizeY()
+            if sizeX*sizeY > size:
+                msg = "Can't export image over %s pixels. " \
+                      "See 'omero.client.download_as.max_size'" % size
+                log("  ** %s. **" % msg)
+                if len(images) == 1:
+                    return None, msg
+                continue
+            else:
+                log("Exporting image as %s: %s" % (format, img.getName()))
+
             log("\n----------- Saving planes from image: '%s' ------------"
                 % img.getName())
             sizeC = img.getSizeC()


### PR DESCRIPTION
This improves handling of Big images in Batch Image Export script.

Previously, the first check was the 'omero.client.download_as.max_size' setting (regardless of which format you were exporting). And if smaller than this limit then OME-TIFF export would go ahead, even if image was a 'Big' (tiled) image that is not supported by OME-TIFF exporter service.

Now, we first check the export format.
If OME-TIFF, then we check if it's a 'Big' (tiled) image.
Otherwise we check if it's under the 'omero.client.download_as.max_size' limit (12k \* 12k by default).

To test:
- Try to export a single image (over 12k \* 12k) as JPG / PNG. Should get sensible message in scripts activities and log.
- Try to export a single 'Big' image at OME-TIFF (can use same image as above). Should get a different message in scripts activities and log.
- Try to export multiple images as OME-TIFF or PNG/JPG. If some are too big these will give message in log. If none are export (all too big) should see reasonable message. Otherwise will get zip.

![screen shot 2016-05-17 at 16 47 40](https://cloud.githubusercontent.com/assets/900055/15329041/258346fe-1c4f-11e6-8a35-10429249222c.png)
