### PR TITLE
Batch Image Export resize

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -132,7 +132,8 @@ def savePlane(image, format, cName, zRange, projectZ, t=0, channel=None,
     if zoomPercent:
         w, h = plane.size
         fraction = (float(zoomPercent) / 100)
-        plane = plane.resize((w * fraction, h * fraction), Image.ANTIALIAS)
+        plane = plane.resize((int(w * fraction), int(h * fraction)),
+                             Image.ANTIALIAS)
 
     if format == "PNG":
         imgName = makeImageName(


### PR DESCRIPTION
This fixes a tiny bug when exporting images with Zoom > 100%

To test:
- Run Batch Image Export script on an image and choose a "Zoom" parameter of E.g. 200%.
- Images should be exported as jpeg/png but resized by the chosen amount (previously script failed).
