### PR TITLE
Fix time Increment issues

### DIFF
--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -432,7 +432,8 @@ def processImages(conn, scriptParams):
         elif "Time_Increment" in scriptParams:
             tInterval = scriptParams["Time_Increment"]
         else:
-            print "Metadata does not contain Time Increment parameter: Please manually set this value to get accurate estimate of the kinetics"
+            print "Metadata does not contain Time Increment parameter:
+            print Please manually set this value to get accurate estimate of the kinetics"
             print "Default value set : Time_Increment = 1 sec/frame"
             tInterval = 1.0
 

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -419,18 +419,22 @@ def processImages(conn, scriptParams):
         # look-up the interval for each time-point
         tInterval = None
         infos = list(pixels.copyPlaneInfo(theC=0, theT=sizeT-1, theZ=0))
-        if len(infos) > 0 and infos[0].getDeltaT() is not None:
+        if pixels.timeIncrement is not None:
+            print "pixels.timeIncrement", pixels.timeIncrement
+            tInterval = pixels.timeIncrement
+        elif len(infos) > 0 and infos[0].getDeltaT() is not None:
             duration = infos[0].getDeltaT(units="SECOND").getValue()
             print "duration", duration
             if sizeT == 1:
                 tInterval = duration
             else:
                 tInterval = duration/(sizeT-1)
-        elif pixels.timeIncrement is not None:
-            print "pixels.timeIncrement", pixels.timeIncrement
-            tInterval = pixels.timeIncrement
         elif "Time_Increment" in scriptParams:
             tInterval = scriptParams["Time_Increment"]
+        else:
+            print "Metadata does not contain Time Increment parameter: Please manually set this value to get accurate estimate of the kinetics"
+            print "Default value set : Time_Increment = 1 sec/frame"
+            tInterval = 1.0
 
         pixel_size = None
         if pixels.physicalSizeX is not None:


### PR DESCRIPTION
ref: http://trac.openmicroscopy.org/ome/ticket/13157

Issue:
If no time increment is provided, Kymograph script produces an image where pixel Size X is set, but pixel Size Y is not set.

Fix:
Sets a default value for time_increment parameter (pixel size Y) and warns the user about the default time_increment value in the log

Testing instructions:
Run the script on the following image on Squig: 
ome/team/Balaji/Omero.Scripts_Issue/33676-EB1 dsRed (red) tracking along peripheral SEPT2-YFP filaments (green). Spinning disc confocal microscopy..ome.tiff

Once the kymograph script is completed: 
Please check the logs for the following message:
"Metadata does not contain Time Increment parameter: Please manually set this value to get accurate estimate of the kinetics"
"Default value set : Time_Increment = 1 sec/frame"

And Run the Kymograph_Analysis script and check:
i) If it does throw an exception (Without this PR, the kymograph_analysis script should throw an exception)
ii) If the resultant csv is properly attached to the image and check if the csv opens/makes sense.

@dominikl @will-moore @pwalczysko 
