### PR TITLE
Drop Python 2.6 from the Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "2.7_with_system_site_packages"
 install: pip install flake8


### PR DESCRIPTION
With flake8 3.0.0, Python 2.6 support has been dropped. Instead of capping flake8, this commit cuts 2.6 from the supported matrix and should restore the build.
