### PR TITLE
Combine images pixel size

### DIFF
--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -309,6 +309,7 @@ def pickPixelSizes(pixelSizes):
             # compare - if different, return None
             if (pixSize.getValue() != px.getValue() or
                     pixSize.getUnit() != px.getUnit()):
+                print "Pixel size mismatch! Won't be set: ", pixSize, px
                 return None
     return pixSize
 
@@ -441,7 +442,7 @@ def makeSingleImage(services, parameterMap, imageIds, dataset, colourMap):
     # Set pixel sizes if known
     pixSizeX = pickPixelSizes(pixelSizes['x'])
     pixSizeY = pickPixelSizes(pixelSizes['y'])
-    print pixSizeX, pixSizeY
+    print "Setting pixel sizes... X: %s Y: %s" % (pixSizeX, pixSizeY)
     if pixSizeX is not None or pixSizeY is not None:
         # reload to avoid OptimisticLockException
         pixels = services["queryService"].get('Pixels', pixels.id.val)

--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -294,6 +294,25 @@ def getImageNames(queryService, imageIds):
     return idMap
 
 
+def pickPixelSizes(pixelSizes):
+    """
+    Process a list of pixel sizes and pick sizes to set for new image.
+    If we have different sizes from different images, return None
+    """
+    pixSize = None
+    for px in pixelSizes:
+        if px is None:
+            continue
+        if pixSize is None:
+            pixSize = px
+        else:
+            # compare - if different, return None
+            if (pixSize.getValue() != px.getValue() or
+                    pixSize.getUnit() != px.getUnit()):
+                return None
+    return pixSize
+
+
 def makeSingleImage(services, parameterMap, imageIds, dataset, colourMap):
     """
     This takes the images specified by imageIds, sorts them in to Z,C,T
@@ -369,6 +388,7 @@ def makeSingleImage(services, parameterMap, imageIds, dataset, colourMap):
     pixelsId = image.getPrimaryPixels().getId().getValue()
     rawPixelStoreUpload.setPixelsId(pixelsId, True)
 
+    pixelSizes = {'x': [], 'y': []}
     for theC in range(sizeC):
         minValue = 0
         maxValue = 0
@@ -382,6 +402,9 @@ def makeSingleImage(services, parameterMap, imageIds, dataset, colourMap):
                         "i.id='%d'" % imageId
                     pixels = queryService.findByQuery(query_string, None)
                     plane2D = getPlane(rawPixelStore, pixels, planeZ, 0, 0)
+                    # Note pixels sizes (may be None)
+                    pixelSizes['x'].append(pixels.getPhysicalSizeX())
+                    pixelSizes['y'].append(pixels.getPhysicalSizeY())
                 else:
                     print "Creating blank plane for theZ, theC, theT",\
                         theZ, theC, theT
@@ -414,6 +437,19 @@ def makeSingleImage(services, parameterMap, imageIds, dataset, colourMap):
         lc.setName(rstring(cNames[i]))
         updateService.saveObject(lc)
         i += 1
+
+    # Set pixel sizes if known
+    pixSizeX = pickPixelSizes(pixelSizes['x'])
+    pixSizeY = pickPixelSizes(pixelSizes['y'])
+    print pixSizeX, pixSizeY
+    if pixSizeX is not None or pixSizeY is not None:
+        # reload to avoid OptimisticLockException
+        pixels = services["queryService"].get('Pixels', pixels.id.val)
+        if pixSizeX is not None:
+            pixels.setPhysicalSizeX(pixSizeX)
+        if pixSizeY is not None:
+            pixels.setPhysicalSizeY(pixSizeY)
+        services["updateService"].saveObject(pixels)
 
     # put the image in dataset, if specified.
     if dataset and dataset.canLink():

--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -309,7 +309,8 @@ def pickPixelSizes(pixelSizes):
             # compare - if different, return None
             if (pixSize.getValue() != px.getValue() or
                     pixSize.getUnit() != px.getUnit()):
-                print "Pixel size mismatch! Won't be set: ", pixSize, px
+                print ("Pixel size mismatch! The mismatched dimension(s)"
+                       " will not be set: "), pixSize, px
                 return None
     return pixSize
 


### PR DESCRIPTION
See https://trello.com/c/e8t6LrDB/197-combine-images-script-ignores-pixel-size

If images used in the CombineImages script have pixel sizes set, the script will pick these sizes and set them on the new image.

We need to test combining images that have:
- No pixel sizes set
- Same pixel sizes set in both/all
- Different pixel sizes in both images

We can set pixel sizes on test images using

```
$ omero shell --login
conn = omero.gateway.BlitzGateway(client_obj=client)
from omero.model.enums import UnitsLength
i = conn.getObject("Image", 1234)
u = omero.model.LengthI(9.8, UnitsLength.ANGSTROM)
p = i.getPrimaryPixels()._obj
p.setPhysicalSizeX(u)
p.setPhysicalSizeY(u)
conn.getUpdateService().saveObject(p)
```

To test:
- Pick a couple of single-plane images of same width & height. Easiest if these have no pixel sizes set initially.
- Try combining these. New image will have no pixel sizes set
- Set pixel size X on both images to the same value
- Set pixel size Y on just one image
- Try combining images. Size X and Size Y should be set on new image.
- Finally set Size Y on the other image, to a different value than above.
- Try combining images. Size Y should not be set on new image.
- Check info for each script run above - should see basic info like:

```
Pixel size mismatch! Won't be set:  1.5 MICROMETER 1.25 MICROMETER
Setting pixel sizes... X: None Y: 1.5 MICROMETER
```
