### PR TITLE
Remove Image.fromarray

### DIFF
--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -44,6 +44,7 @@ from omero.rtypes import rlong, rstring, robject
 import omero.scripts as scripts
 from numpy import math, zeros, hstack, vstack
 import logging
+import io
 try:
     from PIL import Image
 except ImportError:
@@ -58,15 +59,17 @@ def numpyToImage(plane):
     """
 
     from numpy import int32
+    from matplotlib.image import imsave
 
+    buf = io.BytesIO()
     if plane.dtype.name not in ('uint8', 'int8'):
         # int32 is handled by PIL (not uint32 etc). TODO: support floats
         convArray = zeros(plane.shape, dtype=int32)
         convArray += plane
-        # Trac#11912 PIL < 1.1.7 fromarray doesn't handle 16 bit images
-        return Image.fromstring(
-            'I', (plane.shape[1], plane.shape[0]), convArray)
-    return Image.fromarray(plane)
+        imsave(buf, convArray)
+    else:
+        imsave(buf, plane)
+    return Image.open(buf)
 
 
 def getLineData(pixels, x1, y1, x2, y2, lineW=2, theZ=0, theC=0, theT=0):

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
- components/tools/OmeroPy/scripts/omero/analysis_scripts/Kymograph.py
 
 -----------------------------------------------------------------------------
   Copyright (C) 2006-2016 University of Dundee. All rights reserved.

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -529,4 +529,4 @@ same sizeC as input.""",
         client.setOutput("Message", rstring(message))
 
     finally:
-        conn.close()
+        client.closeSession()

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -124,7 +124,7 @@ def getLineData(pixels, x1, y1, x2, y2, lineW=2, theZ=0, theC=0, theT=0):
         pad_data = zeros((pad_bottom, data_w), dtype=plane.dtype)
         plane = vstack((plane, pad_data))
 
-    pil = scriptUtil.numpyToImage(plane, (plane.min(), plane.max()), int32)
+    pil = scriptUtil.numpy_to_image(plane, (plane.min(), plane.max()), int32)
     # pil.show()
 
     # Now need to rotate so that x1,y1 is horizontally to the left of x2,y2

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -529,4 +529,4 @@ same sizeC as input.""",
         client.setOutput("Message", rstring(message))
 
     finally:
-        client.closeSession()
+        conn.close()

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -437,4 +437,4 @@ and outputs the data as CSV files, for plotting in e.g. Excel.""",
         client.setOutput("Message", rstring(message))
 
     finally:
-        client.closeSession()
+        conn.close()

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -437,4 +437,4 @@ and outputs the data as CSV files, for plotting in e.g. Excel.""",
         client.setOutput("Message", rstring(message))
 
     finally:
-        conn.close()
+        client.closeSession()

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -121,7 +121,7 @@ def getLineData(pixels, x1, y1, x2, y2, lineW=2, theZ=0, theC=0, theT=0):
         pad_data = zeros((pad_bottom, data_w), dtype=plane.dtype)
         plane = vstack((plane, pad_data))
 
-    pil = scriptUtil.numpyToImage(plane, (plane.min(), plane.max()), int32)
+    pil = scriptUtil.numpy_to_image(plane, (plane.min(), plane.max()), int32)
     # pil.show()
 
     # Now need to rotate so that x1,y1 is horizontally to the left of x2,y2

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -41,6 +41,7 @@ import omero.scripts as scripts
 import omero.util.script_utils as scriptUtil
 from numpy import math, zeros, hstack, vstack, average
 import logging
+import io
 try:
     from PIL import Image
 except ImportError:
@@ -55,15 +56,17 @@ def numpyToImage(plane):
     """
 
     from numpy import int32
+    from matplotlib.image import imsave
 
+    buf = io.BytesIO()
     if plane.dtype.name not in ('uint8', 'int8'):
         # int32 is handled by PIL (not uint32 etc). TODO: support floats
         convArray = zeros(plane.shape, dtype=int32)
         convArray += plane
-        # Trac#11912 PIL < 1.1.7 fromarray doesn't handle 16 bit images
-        return Image.fromstring(
-            'I', (plane.shape[1], plane.shape[0]), convArray)
-    return Image.fromarray(plane)
+        imsave(buf, convArray)
+    else:
+        imsave(buf, plane)
+    return Image.open(buf)
 
 
 def getLineData(pixels, x1, y1, x2, y2, lineW=2, theZ=0, theC=0, theT=0):

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -45,8 +45,7 @@ import logging
 logger = logging.getLogger('plot_profile')
 
 
-def getLineData(pixels, minMax, x1, y1, x2, y2, lineW=2, theZ=0, theC=0,
-                theT=0):
+def getLineData(pixels, x1, y1, x2, y2, lineW=2, theZ=0, theC=0, theT=0):
     """
     Grabs pixel data covering the specified line, and rotates it horizontally
     so that x1,y1 is to the left,
@@ -55,7 +54,6 @@ def getLineData(pixels, minMax, x1, y1, x2, y2, lineW=2, theZ=0, theC=0,
     to PIL and back (may change dtype.)
 
     @param pixels:          PixelsWrapper object
-    @param minMax:          The min, max values for the specified plane
     @param x1, y1, x2, y2:  Coordinates of line
     @param lineW:           Width of the line we want
     @param theZ:            Z index within pixels
@@ -124,7 +122,7 @@ def getLineData(pixels, minMax, x1, y1, x2, y2, lineW=2, theZ=0, theC=0,
         pad_data = zeros((pad_bottom, data_w), dtype=plane.dtype)
         plane = vstack((plane, pad_data))
 
-    pil = scriptUtil.numpyToImage(plane, minMax, int32)
+    pil = scriptUtil.numpyToImage(plane, (plane.min(), plane.max()), int32)
     # pil.show()
 
     # Now need to rotate so that x1,y1 is horizontally to the left of x2,y2
@@ -176,13 +174,6 @@ def processPolyLines(conn, scriptParams, image, polylines, lineWidth, fout):
     @param polylines:       list of theT:T, theZ:Z, points: list of (x,y)}
     """
     pixels = image.getPrimaryPixels()
-
-    channelMinMax = []
-    for c in image.getChannels():
-        minC = c.getWindowMin()
-        maxC = c.getWindowMax()
-        channelMinMax.append((minC, maxC))
-
     theCs = scriptParams['Channels']
 
     for pl in polylines:
@@ -196,7 +187,7 @@ def processPolyLines(conn, scriptParams, image, polylines, lineWidth, fout):
                 x1, y1 = points[l]
                 x2, y2 = points[l+1]
                 ld = getLineData(
-                    pixels, channelMinMax[theC], x1, y1, x2, y2, lineWidth,
+                    pixels, x1, y1, x2, y2, lineWidth,
                     theZ, theC, theT)
                 lData.append(ld)
             lineData = hstack(lData)
@@ -239,12 +230,6 @@ def processLines(conn, scriptParams, image, lines, lineWidth, fout):
     """
 
     pixels = image.getPrimaryPixels()
-    channelMinMax = []
-    for c in image.getChannels():
-        minC = c.getWindowMin()
-        maxC = c.getWindowMax()
-        channelMinMax.append((minC, maxC))
-
     theCs = scriptParams['Channels']
 
     for l in lines:
@@ -253,7 +238,7 @@ def processLines(conn, scriptParams, image, lines, lineWidth, fout):
         roiId = l['id']
         for theC in theCs:
             lineData = []
-            lineData = getLineData(pixels, channelMinMax[theC], l['x1'],
+            lineData = getLineData(pixels, l['x1'],
                                    l['y1'], l['x2'], l['y2'], lineWidth,
                                    theZ, theC, theT)
 

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
- components/tools/OmeroPy/scripts/omero/analysis_scripts/Plot_Profile.py
 
 -----------------------------------------------------------------------------
   Copyright (C) 2006-2016 University of Dundee. All rights reserved.

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -47,7 +47,7 @@ from omero.gateway import BlitzGateway
 import omero
 from omero.rtypes import rint, rlong, rstring, robject, wrap
 import os
-import StringIO
+import io
 from omero.constants.namespaces import NSCREATED
 from omero.constants.projection import ProjectionType
 from datetime import date
@@ -191,7 +191,7 @@ def createMovieFigure(conn, pixelIds, tIndexes, zStart, zEnd, width, height,
                     planeDef.t = time
                     renderedImg = re.renderCompressed(planeDef)
                 # create images and resize, add to list
-                image = Image.open(StringIO.StringIO(renderedImg))
+                image = Image.open(io.BytesIO(renderedImg))
                 resizedImage = imgUtil.resizeImage(image, width, height)
                 renderedImages.append(resizedImage)
 

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -49,7 +49,7 @@ from omero.constants.namespaces import NSCREATED
 import omero.model
 from omero.constants.projection import ProjectionType
 import os
-import StringIO
+import io
 from datetime import date
 
 try:
@@ -186,7 +186,7 @@ def getROImovieView(re, queryService, pixels, timeShapeMap, mergedIndexes,
 
         merged = re.renderProjectedCompressed(
             algorithm, timepoint, stepping, proStart, proEnd)
-        fullMergedImage = Image.open(StringIO.StringIO(merged))
+        fullMergedImage = Image.open(io.BytesIO(merged))
         if fullFirstFrame is None:
             fullFirstFrame = fullMergedImage
         roiMergedImage = fullMergedImage.crop(box)

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -49,7 +49,7 @@ from omero.rtypes import rlong, robject, rstring, wrap, unwrap
 import os
 from omero.constants.namespaces import NSCREATED
 from omero.constants.projection import ProjectionType
-import StringIO
+import io
 from datetime import date
 
 try:
@@ -179,11 +179,11 @@ def getROIsplitView(re, pixels, zStart, zEnd, splitIndexes, channelNames,
                 regionDef.height = roiHeight
                 planeDef.region = regionDef
                 rPlane = re.renderCompressed(planeDef)
-                roiImage = Image.open(StringIO.StringIO(rPlane))
+                roiImage = Image.open(io.BytesIO(rPlane))
             else:
                 projection = re.renderProjectedCompressed(
                     algorithm, tIndex, stepping, proStart, proEnd)
-                fullImage = Image.open(StringIO.StringIO(projection))
+                fullImage = Image.open(io.BytesIO(projection))
                 roiImage = fullImage.crop(box)
                 roiImage.load()
                 # hoping that when we zoom, don't zoom fullImage
@@ -215,7 +215,7 @@ def getROIsplitView(re, pixels, zStart, zEnd, splitIndexes, channelNames,
         planeDef.z = proStart
         planeDef.t = tIndex
         merged = re.renderCompressed(planeDef)
-    fullMergedImage = Image.open(StringIO.StringIO(merged))
+    fullMergedImage = Image.open(io.BytesIO(merged))
     roiMergedImage = fullMergedImage.crop(box)
     # make sure this is not just a lazy copy of the full image
     roiMergedImage.load()

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -47,7 +47,7 @@ from omero.rtypes import rint, rlong, rstring, robject, wrap
 from omero.constants.namespaces import NSCREATED
 from omero.constants.projection import ProjectionType
 import os
-import StringIO
+import io
 from datetime import date
 
 try:
@@ -286,14 +286,14 @@ def getSplitView(conn, pixelIds, zStart, zEnd, splitIndexes, channelNames,
             if img is None:
                 im = Image.new(mode, (sizeX, sizeY), (0, 0, 0))
             else:
-                im = Image.open(StringIO.StringIO(img))
+                im = Image.open(io.BytesIO(img))
             i = imgUtil.resizeImage(im, width, height)
             imgUtil.pasteImage(i, canvas, px, py)
             px = px + width + spacer
             col = col + 1
 
         # add combined image, after resizing and adding scale bar
-        i = Image.open(StringIO.StringIO(overlay))
+        i = Image.open(io.BytesIO(overlay))
         scaledImage = imgUtil.resizeImage(i, width, height)
         if scalebar:
             xIndent = spacer


### PR DESCRIPTION
Remove usage of  ``Image.fromarray`` method
Prefer usage of io instead of StringIO

The ``numpyToImage`` method has been moved to script_utils instead of being duplicated

--depends-on https://github.com/openmicroscopy/openmicroscopy/pull/4914