### PR TITLE
T and Z fix for Images_from_ROIs.py

### DIFF
--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -158,8 +158,16 @@ def getRectangles(conn, imageId):
         for shape in roi.copyShapes():
             if type(shape) == omero.model.RectangleI:
                 # check t range and z range for every rectangle
-                t = shape.getTheT().getValue()
-                z = shape.getTheZ().getValue()
+                # t and z (and c) for shape is optional
+                # https://www.openmicroscopy.org/site/support/omero5.2/developers/Model/EveryObject.html#shape
+                try:
+                    t = shape.getTheT().getValue()
+                except:
+                    t = 0
+                try:
+                    z = shape.getTheZ().getValue()
+                except:
+                    z = 0
                 if tStart is None:
                     tStart = t
                 if zStart is None:

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -162,11 +162,11 @@ def getRectangles(conn, imageId):
                 # https://www.openmicroscopy.org/site/support/omero5.2/developers/Model/EveryObject.html#shape
                 try:
                     t = shape.getTheT().getValue()
-                except:
+                except AttributeError:
                     t = 0
                 try:
                     z = shape.getTheZ().getValue()
-                except:
+                except AttributeError:
                     z = 0
                 if tStart is None:
                     tStart = t


### PR DESCRIPTION
T, Z and C are optional. The script execution fails if T or Z is unset.

Testing: create shape without explicitly setting T and Z and it should run smoothly until completion.