### PR TITLE
Roi

### DIFF
--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -369,7 +369,7 @@ def processImages(conn, scriptParams):
                 the_t = unwrap(s.getTheT())
                 the_z = unwrap(s.getTheZ())
                 z = 0
-                z = 0
+                t = 0
                 if the_t is not None:
                     t = the_t
                 if the_z is not None:

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -382,7 +382,7 @@ def processImages(conn, scriptParams):
                     y1 = s.getY1().getValue()
                     y2 = s.getY2().getValue()
                     lines[t] = {'theZ': z, 'x1': x1, 'y1': y1, 'x2': x2,
-                                   'y2': y2}
+                                'y2': y2}
 
                 elif type(s) == omero.model.PolylineI:
                     points = pointsStringToXYlist(s.getPoints().getValue())

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -39,7 +39,7 @@ sizeC as input.
 from omero.gateway import BlitzGateway
 import omero
 import omero.util.script_utils as scriptUtil
-from omero.rtypes import rlong, rstring, robject
+from omero.rtypes import rlong, rstring, robject, unwrap
 import omero.scripts as scripts
 from numpy import math, zeros, hstack, vstack
 import logging
@@ -366,8 +366,14 @@ def processImages(conn, scriptParams):
             for s in roi.copyShapes():
                 if s is None:
                     continue
-                theZ = s.getTheZ() and s.getTheZ().getValue() or 0
-                theT = s.getTheT() and s.getTheT().getValue() or 0
+                the_t = unwrap(s.getTheT())
+                the_z = unwrap(s.getTheZ())
+                z = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
                 # TODO: Add some filter of shapes. E.g. text? / 'lines' only
                 # etc.
                 if type(s) == omero.model.LineI:
@@ -375,12 +381,12 @@ def processImages(conn, scriptParams):
                     x2 = s.getX2().getValue()
                     y1 = s.getY1().getValue()
                     y2 = s.getY2().getValue()
-                    lines[theT] = {'theZ': theZ, 'x1': x1, 'y1': y1, 'x2': x2,
+                    lines[t] = {'theZ': z, 'x1': x1, 'y1': y1, 'x2': x2,
                                    'y2': y2}
 
                 elif type(s) == omero.model.PolylineI:
                     points = pointsStringToXYlist(s.getPoints().getValue())
-                    polylines[theT] = {'theZ': theZ, 'points': points}
+                    polylines[t] = {'theZ': z, 'points': points}
 
             if len(lines) > 0:
                 newImg = linesKymograph(

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -324,7 +324,7 @@ def processImages(conn, scriptParams):
                 the_t = unwrap(s.getTheT())
                 the_z = unwrap(s.getTheZ())
                 z = 0
-                z = 0
+                t = 0
                 if the_t is not None:
                     t = the_t
                 if the_z is not None:

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -35,7 +35,7 @@ saving the intensity of chosen channels to Excel (csv) files.
 
 from omero.gateway import BlitzGateway
 import omero
-from omero.rtypes import rstring, rlong, robject
+from omero.rtypes import rstring, rlong, robject, unwrap
 import omero.scripts as scripts
 import omero.util.script_utils as scriptUtil
 from numpy import math, zeros, hstack, vstack, average
@@ -321,8 +321,14 @@ def processImages(conn, scriptParams):
         for roi in result.rois:
             roiId = roi.getId().getValue()
             for s in roi.copyShapes():
-                theZ = s.getTheZ() and s.getTheZ().getValue() or 0
-                theT = s.getTheT() and s.getTheT().getValue() or 0
+                the_t = unwrap(s.getTheT())
+                the_z = unwrap(s.getTheZ())
+                z = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
                 # TODO: Add some filter of shapes. E.g. text? / 'lines' only
                 # etc.
                 if type(s) == omero.model.LineI:
@@ -330,12 +336,12 @@ def processImages(conn, scriptParams):
                     x2 = s.getX2().getValue()
                     y1 = s.getY1().getValue()
                     y2 = s.getY2().getValue()
-                    lines.append({'id': roiId, 'theT': theT, 'theZ': theZ,
+                    lines.append({'id': roiId, 'theT': t, 'theZ': z,
                                   'x1': x1, 'y1': y1, 'x2': x2, 'y2': y2})
 
                 elif type(s) == omero.model.PolylineI:
                     points = pointsStringToXYlist(s.getPoints().getValue())
-                    polylines.append({'id': roiId, 'theT': theT, 'theZ': theZ,
+                    polylines.append({'id': roiId, 'theT': t, 'theZ': z,
                                       'points': points})
 
         if len(lines) == 0 and len(polylines) == 0:

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -44,7 +44,7 @@ import omero.util.imageUtil as imgUtil
 import omero.util.figureUtil as figUtil
 import omero.util.script_utils as scriptUtil
 from omero.gateway import BlitzGateway
-from omero.rtypes import rlong, rint, rstring, robject, wrap
+from omero.rtypes import rlong, rint, rstring, robject, wrap, unwrap
 from omero.constants.namespaces import NSCREATED
 import omero.model
 from omero.constants.projection import ProjectionType
@@ -280,8 +280,14 @@ def getRectangle(roiService, imageId, roiLabel):
 
         timeShapeMap = {}  # map of tIndex: (x,y,zMin,zMax) for a single roi
         for shape in rectangles:
-            t = shape.getTheT().getValue()
-            z = shape.getTheZ().getValue()
+            the_t = unwrap(shape.getTheT())
+            the_z = unwrap(shape.getTheZ())
+            t = 0
+            z = 0
+            if the_t is not None:
+                t = the_t
+            if the_z is not None:
+                z = the_z
             x = int(shape.getX().getValue())
             y = int(shape.getY().getValue())
             text = shape.getTextValue() and shape.getTextValue().getValue() \

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -332,8 +332,14 @@ def getRectangle(roiService, imageId, roiLabel):
         # go through all the shapes of the ROI
         for shape in roi.copyShapes():
             if type(shape) == omero.model.RectangleI:
-                t = unwrap(shape.getTheT())
-                z = unwrap(shape.getTheZ())
+                the_t = unwrap(shape.getTheT())
+                the_z = unwrap(shape.getTheZ())
+                t = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
                 x = shape.getX().getValue()
                 y = shape.getY().getValue()
                 tv = shape.getTextValue()

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -38,7 +38,7 @@ images with the regions within the ROIs, and saves them back to the server.
 import omero
 import omero.scripts as scripts
 from omero.gateway import BlitzGateway
-from omero.rtypes import rstring, rlong, robject
+from omero.rtypes import rstring, rlong, robject, unwrap
 import omero.util.script_utils as script_utils
 from omero.util.tiles import TileLoopIteration, RPSTileLoop
 from omero.model import PixelsI
@@ -160,14 +160,15 @@ def getRectangles(conn, imageId):
                 # check t range and z range for every rectangle
                 # t and z (and c) for shape is optional
                 # https://www.openmicroscopy.org/site/support/omero5.2/developers/Model/EveryObject.html#shape
-                try:
-                    t = shape.getTheT().getValue()
-                except AttributeError:
-                    t = 0
-                try:
-                    z = shape.getTheZ().getValue()
-                except AttributeError:
-                    z = 0
+                the_t = unwrap(shape.getTheT())
+                the_z = unwrap(shape.getTheZ())
+                t = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
+
                 if tStart is None:
                     tStart = t
                 if zStart is None:


### PR DESCRIPTION
Handle the cases where z or t is not set on shape. This uses ``omero.rtypes.unwrap``.
This will be tested with the integration tests
https://github.com/openmicroscopy/openmicroscopy/pull/4953

