### PR TITLE
Big Images_From_ROIs (rebased onto dev_5_2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "2.7_with_system_site_packages"
 install: pip install flake8

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -486,6 +486,7 @@ def processImages(conn, scriptParams):
 
     return newKymographs, message
 
+
 if __name__ == "__main__":
 
     dataTypes = [rstring('Image')]

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -40,7 +40,7 @@ sizeC as input.
 from omero.gateway import BlitzGateway
 import omero
 import omero.util.script_utils as scriptUtil
-from omero.rtypes import rlong, rstring, robject
+from omero.rtypes import rlong, rstring, robject, unwrap
 import omero.scripts as scripts
 from numpy import math, zeros, hstack, vstack
 import logging
@@ -387,8 +387,14 @@ def processImages(conn, scriptParams):
             for s in roi.copyShapes():
                 if s is None:
                     continue
-                theZ = s.getTheZ() and s.getTheZ().getValue() or 0
-                theT = s.getTheT() and s.getTheT().getValue() or 0
+                the_t = unwrap(s.getTheT())
+                the_z = unwrap(s.getTheZ())
+                z = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
                 # TODO: Add some filter of shapes. E.g. text? / 'lines' only
                 # etc.
                 if type(s) == omero.model.LineI:
@@ -396,12 +402,12 @@ def processImages(conn, scriptParams):
                     x2 = s.getX2().getValue()
                     y1 = s.getY1().getValue()
                     y2 = s.getY2().getValue()
-                    lines[theT] = {'theZ': theZ, 'x1': x1, 'y1': y1, 'x2': x2,
-                                   'y2': y2}
+                    lines[t] = {'theZ': z, 'x1': x1, 'y1': y1, 'x2': x2,
+                                'y2': y2}
 
                 elif type(s) == omero.model.PolylineI:
                     points = pointsStringToXYlist(s.getPoints().getValue())
-                    polylines[theT] = {'theZ': theZ, 'points': points}
+                    polylines[t] = {'theZ': z, 'points': points}
 
             if len(lines) > 0:
                 newImg = linesKymograph(

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -390,7 +390,7 @@ def processImages(conn, scriptParams):
                 the_t = unwrap(s.getTheT())
                 the_z = unwrap(s.getTheZ())
                 z = 0
-                z = 0
+                t = 0
                 if the_t is not None:
                     t = the_t
                 if the_z is not None:

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -346,7 +346,7 @@ def processImages(conn, scriptParams):
                 the_t = unwrap(s.getTheT())
                 the_z = unwrap(s.getTheZ())
                 z = 0
-                z = 0
+                t = 0
                 if the_t is not None:
                     t = the_t
                 if the_z is not None:

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -36,7 +36,7 @@ saving the intensity of chosen channels to Excel (csv) files.
 
 from omero.gateway import BlitzGateway
 import omero
-from omero.rtypes import rstring, rlong, robject
+from omero.rtypes import rstring, rlong, robject, unwrap
 import omero.scripts as scripts
 import omero.util.script_utils as scriptUtil
 from numpy import math, zeros, hstack, vstack, average
@@ -343,8 +343,14 @@ def processImages(conn, scriptParams):
         for roi in result.rois:
             roiId = roi.getId().getValue()
             for s in roi.copyShapes():
-                theZ = s.getTheZ() and s.getTheZ().getValue() or 0
-                theT = s.getTheT() and s.getTheT().getValue() or 0
+                the_t = unwrap(s.getTheT())
+                the_z = unwrap(s.getTheZ())
+                z = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
                 # TODO: Add some filter of shapes. E.g. text? / 'lines' only
                 # etc.
                 if type(s) == omero.model.LineI:
@@ -352,12 +358,12 @@ def processImages(conn, scriptParams):
                     x2 = s.getX2().getValue()
                     y1 = s.getY1().getValue()
                     y2 = s.getY2().getValue()
-                    lines.append({'id': roiId, 'theT': theT, 'theZ': theZ,
+                    lines.append({'id': roiId, 'theT': t, 'theZ': z,
                                   'x1': x1, 'y1': y1, 'x2': x2, 'y2': y2})
 
                 elif type(s) == omero.model.PolylineI:
                     points = pointsStringToXYlist(s.getPoints().getValue())
-                    polylines.append({'id': roiId, 'theT': theT, 'theZ': theZ,
+                    polylines.append({'id': roiId, 'theT': t, 'theZ': z,
                                       'points': points})
 
         if len(lines) == 0 and len(polylines) == 0:

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -401,6 +401,7 @@ def processImages(conn, scriptParams):
 
     return fileAnns, message
 
+
 if __name__ == "__main__":
 
     dataTypes = [rstring('Image')]

--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -622,5 +622,6 @@ See http://help.openmicroscopy.org/export.html#batch""",
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runScript()

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -814,5 +814,6 @@ def runAsScript():
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -675,5 +675,6 @@ See http://help.openmicroscopy.org/publish.html#movies""",
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -44,7 +44,7 @@ import omero.util.imageUtil as imgUtil
 import omero.util.figureUtil as figUtil
 import omero.util.script_utils as scriptUtil
 from omero.gateway import BlitzGateway
-from omero.rtypes import rlong, rint, rstring, robject, wrap
+from omero.rtypes import rlong, rint, rstring, robject, wrap, unwrap
 from omero.constants.namespaces import NSCREATED
 import omero.model
 from omero.constants.projection import ProjectionType
@@ -280,8 +280,14 @@ def getRectangle(roiService, imageId, roiLabel):
 
         timeShapeMap = {}  # map of tIndex: (x,y,zMin,zMax) for a single roi
         for shape in rectangles:
-            t = shape.getTheT().getValue()
-            z = shape.getTheZ().getValue()
+            the_t = unwrap(shape.getTheT())
+            the_z = unwrap(shape.getTheZ())
+            t = 0
+            z = 0
+            if the_t is not None:
+                t = the_t
+            if the_z is not None:
+                z = the_z
             x = int(shape.getX().getValue())
             y = int(shape.getY().getValue())
             text = shape.getTextValue() and shape.getTextValue().getValue() \

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -841,5 +841,6 @@ any ROI."""
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -332,8 +332,14 @@ def getRectangle(roiService, imageId, roiLabel):
         # go through all the shapes of the ROI
         for shape in roi.copyShapes():
             if type(shape) == omero.model.RectangleI:
-                t = unwrap(shape.getTheT())
-                z = unwrap(shape.getTheZ())
+                the_t = unwrap(shape.getTheT())
+                the_z = unwrap(shape.getTheZ())
+                t = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
                 x = shape.getX().getValue()
                 y = shape.getY().getValue()
                 tv = shape.getTextValue()

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -943,5 +943,6 @@ See http://help.openmicroscopy.org/publish.html#figures""",
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -825,5 +825,6 @@ See http://help.openmicroscopy.org/publish.html#figures""",
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -550,5 +550,6 @@ See http://help.openmicroscopy.org/publish.html#figures""",
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/setup_scripts/FLIM_initialise.py
+++ b/omero/setup_scripts/FLIM_initialise.py
@@ -73,5 +73,6 @@ def runAsScript():
     finally:
         client.closeSession()
 
+
 if __name__ == '__main__':
     runAsScript()

--- a/omero/util_scripts/Channel_Offsets.py
+++ b/omero/util_scripts/Channel_Offsets.py
@@ -388,5 +388,6 @@ See http://help.openmicroscopy.org/scripts.html""",
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -645,5 +645,6 @@ See http://help.openmicroscopy.org/scripts.html""",
         client.closeSession()
         printDuration()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/util_scripts/Dataset_To_Plate.py
+++ b/omero/util_scripts/Dataset_To_Plate.py
@@ -354,5 +354,6 @@ See http://help.openmicroscopy.org/scripts.html""",
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -4,7 +4,7 @@
  components/tools/OmeroPy/scripts/omero/util_scripts/Images_From_ROIs.py
 
 -----------------------------------------------------------------------------
-  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
 
 
   This program is free software; you can redistribute it and/or modify
@@ -40,6 +40,8 @@ import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 from omero.rtypes import rstring, rlong, robject
 import omero.util.script_utils as script_utils
+from omero.util.tiles import TileLoopIteration, RPSTileLoop
+from omero.model import PixelsI
 
 import os
 
@@ -53,6 +55,87 @@ def printDuration(output=True):
         startTime = time.time()
     if output:
         print "Script timer = %s secs" % (time.time() - startTime)
+
+
+def create_image_from_tiles(conn, source, image_name, description, box):
+
+    pixelsService = conn.getPixelsService()
+    queryService = conn.getQueryService()
+    xbox, ybox, wbox, hbox, z1box, z2box, t1box, t2box = box
+    sizeX = wbox
+    sizeY = hbox
+    sizeZ = source.getSizeZ()
+    sizeT = source.getSizeT()
+    sizeC = source.getSizeC()
+    tileWidth = 1024
+    tileHeight = 1024
+    primary_pixels = source.getPrimaryPixels()
+
+    def create_image():
+        query = "from PixelsType as p where p.value='uint8'"
+        pixelsType = queryService.findByQuery(query, None)
+        channelList = range(sizeC)
+        # bytesPerPixel = pixelsType.bitSize.val / 8
+        iId = pixelsService.createImage(
+            sizeX,
+            sizeY,
+            sizeZ,
+            sizeT,
+            channelList,
+            pixelsType,
+            image_name,
+            description,
+            conn.SERVICE_OPTS)
+
+        image = conn.getObject("Image", iId)
+        return image
+
+    # Make a list of all the tiles we're going to need.
+    # This is the SAME ORDER that RPSTileLoop will ask for them.
+    zctTileList = []
+    for t in range(0, sizeT):
+        for c in range(0, sizeC):
+            for z in range(0, sizeZ):
+                for tileOffsetY in range(
+                        0, ((sizeY + tileHeight - 1) / tileHeight)):
+                    for tileOffsetX in range(
+                            0, ((sizeX + tileWidth - 1) / tileWidth)):
+                        x = tileOffsetX * tileWidth
+                        y = tileOffsetY * tileHeight
+                        w = tileWidth
+                        if (w + x > sizeX):
+                            w = sizeX - x
+                        h = tileHeight
+                        if (h + y > sizeY):
+                            h = sizeY - y
+                        tile_xywh = (box[0] + x, box[1] + y, w, h)
+                        zctTileList.append((z, c, t, tile_xywh))
+
+    # This is a generator that will return tiles in the sequence above
+    # getTiles() only opens 1 rawPixelsStore for all the tiles
+    # whereas getTile() opens and closes a rawPixelsStore for each tile.
+    tileGen = primary_pixels.getTiles(zctTileList)
+
+    def nextTile():
+        return tileGen.next()
+
+    class Iteration(TileLoopIteration):
+
+        def run(self, data, z, c, t, x, y, tileWidth, tileHeight, tileCount):
+            # tile2d = mktile(z, c, t, x, y,tileWidth, tileHeight)
+            # tile2d = faketile(tileWidth, tileHeight)
+            tile2d = nextTile()
+            data.setTile(tile2d, z, c, t, x, y, tileWidth, tileHeight)
+
+    new_image = create_image()
+    pid = new_image.getPixelsId()
+    loop = RPSTileLoop(conn.c.sf, PixelsI(pid, False))
+    loop.forEachTile(tileWidth, tileHeight, Iteration())
+
+    for theC in range(sizeC):
+        pixelsService.setChannelGlobalMinMax(pid, theC, float(0), float(255), conn.SERVICE_OPTS)
+
+    return new_image
 
 
 def getRectangles(conn, imageId):
@@ -201,34 +284,43 @@ def processImage(conn, imageId, parameterMap):
     else:
         images = []
         iIds = []
-        for r in rois:
+        bigImageSize = conn.getMaxPlaneSize()
+        bigImagePixelCount = bigImageSize[0] * bigImageSize[1]
+
+        for index, r in enumerate(rois):
+            newName = "%s_%0d" % (imageName, index)
             x, y, w, h, z1, z2, t1, t2 = r
             print "  ROI x: %s y: %s w: %s h: %s z1: %s z2: %s t1: %s t2: %s"\
                 % (x, y, w, h, z1, z2, t1, t2)
 
-            # need a tile generator to get all the planes within the ROI
-            sizeZ = z2-z1 + 1
-            sizeT = t2-t1 + 1
-            sizeC = image.getSizeC()
-            zctTileList = []
-            tile = (x, y, w, h)
-            print "zctTileList..."
-            for z in range(z1, z2+1):
-                for c in range(sizeC):
-                    for t in range(t1, t2+1):
-                        zctTileList.append((z, c, t, tile))
+            if (h * w < bigImagePixelCount):
+                # need a tile generator to get all the planes within the ROI
+                sizeZ = z2-z1 + 1
+                sizeT = t2-t1 + 1
+                sizeC = image.getSizeC()
+                zctTileList = []
+                tile = (x, y, w, h)
+                print "zctTileList..."
+                for z in range(z1, z2+1):
+                    for c in range(sizeC):
+                        for t in range(t1, t2+1):
+                            zctTileList.append((z, c, t, tile))
 
-            def tileGen():
-                for i, t in enumerate(pixels.getTiles(zctTileList)):
-                    yield t
+                def tileGen():
+                    for i, t in enumerate(pixels.getTiles(zctTileList)):
+                        yield t
 
-            print "sizeZ, sizeC, sizeT", sizeZ, sizeC, sizeT
-            description = "Created from image:\n  Name: %s\n  Image ID: %d"\
-                " \n x: %d y: %d" % (imageName, imageId, x, y)
-            newImg = conn.createImageFromNumpySeq(
-                tileGen(), imageName,
-                sizeZ=sizeZ, sizeC=sizeC, sizeT=sizeT,
-                description=description, sourceImageId=imageId)
+                print "sizeZ, sizeC, sizeT", sizeZ, sizeC, sizeT
+                description = "Created from image:\n  Name: %s\n  Image ID: %d"\
+                    " \n x: %d y: %d" % (imageName, imageId, x, y)
+                newImg = conn.createImageFromNumpySeq(
+                    tileGen(), newName,
+                    sizeZ=sizeZ, sizeC=sizeC, sizeT=sizeT,
+                    description=description, sourceImageId=imageId)
+            else:
+                s = time.time()
+                newImg = create_image_from_tiles(conn, image, newName, description, r)
+                print 'Tiled image creation took:', time.time()-s, 'seconds'
 
             print "New Image Id = %s" % newImg.getId()
 
@@ -400,7 +492,7 @@ assumes that all the ROIs on each Image are the same size.""",
             description="If true, make a single Image (stack) from all the"
             " ROIs of each parent Image"),
 
-        version="4.2.0",
+        version="5.3.0",
         authors=["William Moore", "OME Team"],
         institutions=["University of Dundee"],
         contact="ome-users@lists.openmicroscopy.org.uk",

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -294,6 +294,9 @@ def processImage(conn, imageId, parameterMap):
             print "  ROI x: %s y: %s w: %s h: %s z1: %s z2: %s t1: %s t2: %s"\
                 % (x, y, w, h, z1, z2, t1, t2)
 
+            description = "Created from image:"\
+                " \n  Name: %s\n  Image ID: %d"\
+                " \n x: %d y: %d" % (imageName, imageId, x, y)
             if (h * w < bigImagePixelCount):
                 # need a tile generator to get all the planes within the ROI
                 sizeZ = z2-z1 + 1
@@ -310,11 +313,7 @@ def processImage(conn, imageId, parameterMap):
                 def tileGen():
                     for i, t in enumerate(pixels.getTiles(zctTileList)):
                         yield t
-
                 print "sizeZ, sizeC, sizeT", sizeZ, sizeC, sizeT
-                description = "Created from image:"\
-                    " \n  Name: %s\n  Image ID: %d"\
-                    " \n x: %d y: %d" % (imageName, imageId, x, y)
                 newImg = conn.createImageFromNumpySeq(
                     tileGen(), newName,
                     sizeZ=sizeZ, sizeC=sizeC, sizeT=sizeT,

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -57,7 +57,8 @@ def printDuration(output=True):
         print "Script timer = %s secs" % (time.time() - startTime)
 
 
-def create_image_from_tiles(conn, source, image_name, description, box, tileSize):
+def create_image_from_tiles(conn, source, image_name, description,
+                            box, tileSize):
 
     pixelsService = conn.getPixelsService()
     queryService = conn.getQueryService()

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -525,5 +525,6 @@ images using the specified tile size.
         client.closeSession()
         printDuration()
 
+
 if __name__ == "__main__":
     runAsScript()

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -123,8 +123,6 @@ def create_image_from_tiles(conn, source, image_name, description,
     class Iteration(TileLoopIteration):
 
         def run(self, data, z, c, t, x, y, tileWidth, tileHeight, tileCount):
-            # tile2d = mktile(z, c, t, x, y,tileWidth, tileHeight)
-            # tile2d = faketile(tileWidth, tileHeight)
             tile2d = nextTile()
             data.setTile(tile2d, z, c, t, x, y, tileWidth, tileHeight)
 

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -38,7 +38,7 @@ images with the regions within the ROIs, and saves them back to the server.
 import omero
 import omero.scripts as scripts
 from omero.gateway import BlitzGateway
-from omero.rtypes import rstring, rlong, robject
+from omero.rtypes import rstring, rlong, robject, unwrap
 import omero.util.script_utils as script_utils
 from omero.util.tiles import TileLoopIteration, RPSTileLoop
 from omero.model import PixelsI
@@ -157,9 +157,14 @@ def getRectangles(conn, imageId):
         x = None
         for shape in roi.copyShapes():
             if type(shape) == omero.model.RectangleI:
-                # check t range and z range for every rectangle
-                t = shape.getTheT().getValue()
-                z = shape.getTheZ().getValue()
+                the_t = unwrap(shape.getTheT())
+                the_z = unwrap(shape.getTheZ())
+                t = 0
+                z = 0
+                if the_t is not None:
+                    t = the_t
+                if the_z is not None:
+                    z = the_z
                 if tStart is None:
                     tStart = t
                 if zStart is None:

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -133,7 +133,8 @@ def create_image_from_tiles(conn, source, image_name, description, box):
     loop.forEachTile(tileWidth, tileHeight, Iteration())
 
     for theC in range(sizeC):
-        pixelsService.setChannelGlobalMinMax(pid, theC, float(0), float(255), conn.SERVICE_OPTS)
+        pixelsService.setChannelGlobalMinMax(pid, theC, float(0),
+                                             float(255), conn.SERVICE_OPTS)
 
     return new_image
 
@@ -311,7 +312,8 @@ def processImage(conn, imageId, parameterMap):
                         yield t
 
                 print "sizeZ, sizeC, sizeT", sizeZ, sizeC, sizeT
-                description = "Created from image:\n  Name: %s\n  Image ID: %d"\
+                description = "Created from image:"\
+                    " \n  Name: %s\n  Image ID: %d"\
                     " \n x: %d y: %d" % (imageName, imageId, x, y)
                 newImg = conn.createImageFromNumpySeq(
                     tileGen(), newName,
@@ -319,7 +321,8 @@ def processImage(conn, imageId, parameterMap):
                     description=description, sourceImageId=imageId)
             else:
                 s = time.time()
-                newImg = create_image_from_tiles(conn, image, newName, description, r)
+                newImg = create_image_from_tiles(conn, image, newName,
+                                                 description, r)
                 print 'Tiled image creation took:', time.time()-s, 'seconds'
 
             print "New Image Id = %s" % newImg.getId()


### PR DESCRIPTION
This is the same as gh-115 but rebased onto dev_5_2.

----

This allows the `Images_From_ROIs.py` script to create tiled images from 'Big' ROIs. With contributions from @drmatthews.
See https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=7565

To test:
- create Rectangle ROIs of various sizes on a Big image. Some should be bigger than ~3k x 3k and some smaller
- Run the Images_From_ROIs script on the image. It will take a long time, but should create Big images for Big Rectangles and regular non-tiled images for the smaller Rectangles.


The last 2 commits were not in the initial PR but are required
 * flake8 the files
 * 2.6 drop from travis matrix
                