### PR TITLE
Move_Annotations

### DIFF
--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -23,6 +23,7 @@ import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 from omero.model import WellAnnotationLinkI, WellI, ImageAnnotationLinkI
 from omero.rtypes import rstring, rlong
+from omero.constants.metadata import NSINSIGHTRATING
 
 
 ANN_TYPES = {
@@ -91,8 +92,11 @@ def move_annotations(conn, script_params):
     ann_type = script_params['Annotation_Type']
     if ann_type in ANN_TYPES:
         filter_type = ANN_TYPES[ann_type]
+    if ann_type == 'Rating':
+        ns = NSINSIGHTRATING
+    else:
+        ns = script_params.get('Namespace')
     remove_anns = script_params['Remove_Annotations']
-    ns = script_params.get('Namespace')
 
     # Get the Plates or Wells
     objects = conn.getObjects(dtype, ids)

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -34,12 +34,16 @@ ANN_TYPES = {
     'Key-Value': 'MapAnnotationI'
 }
 
+def log(text):
+    """Handles logging statements in a single place."""
+    print text
+
 
 def move_well_annotations(conn, well, ann_type, remove_anns, ns):
     """Move annotations from Images in this Well onto the Well itself."""
-    print "Processing Well:", well.id, well.getWellPos()
+    log("Processing Well:", well.id, well.getWellPos())
     iids = [wellSample.getImage().id for wellSample in well.listChildren()]
-    print "  Image IDs:", iids
+    log("  Image IDs:", iids)
     if len(iids) == 0:
         return 0
 
@@ -61,7 +65,7 @@ def move_well_annotations(conn, well, ann_type, remove_anns, ns):
 
     new_links = []
     for l in old_links:
-        print "    Annotation:", l.child.id.val, l.child.__class__.__name__
+        log("    Annotation:", l.child.id.val, l.child.__class__.__name__)
         link = WellAnnotationLinkI()
         link.parent = WellI(well.id, False)
         link.child = l.child
@@ -69,17 +73,17 @@ def move_well_annotations(conn, well, ann_type, remove_anns, ns):
     try:
         conn.getUpdateService().saveArray(new_links)
     except Exception, ex:
-        print "Failed to create links: ", ex.message
+        log("Failed to create links: ", ex.message)
         return 0
 
     if remove_anns:
-        print "Deleting ImageAnnotation links...", link_ids
+        log("Deleting ImageAnnotation links...", link_ids)
         try:
             for link_id in link_ids:
                 to_delete = ImageAnnotationLinkI(link_id, False)
                 conn.getUpdateService().deleteObject(to_delete)
         except Exception, ex:
-            print "Failed to delete links: ", ex.message
+            log("Failed to delete links: ", ex.message)
     return len(new_links)
 
 
@@ -115,7 +119,7 @@ def move_annotations(conn, script_params):
         elif dtype == 'Screen':
             for screen in objects:
                 plates.extend(list(screen.listChildren()))
-        print "Found Plates:", plates
+        log("Found Plates:", plates)
         for plate in plates:
             for well in plate.listChildren():
                 ann_count = move_well_annotations(conn, well, filter_type,
@@ -169,7 +173,7 @@ def run_script():
         conn = BlitzGateway(client_obj=client)
 
         script_params = client.getInputs(unwrap=True)
-        print script_params
+        log(script_params)
 
         # call the main script
         anns_moved = move_annotations(conn, script_params)

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -25,6 +25,7 @@ from omero.model import ExperimenterI, \
                         ImageAnnotationLinkI, \
                         WellAnnotationLinkI, \
                         WellI
+from omero.cmd import Delete2
 from omero.sys import ParametersI, Filter
 from omero.rtypes import rstring, rlong, robject
 from omero.constants.metadata import NSINSIGHTRATING
@@ -109,9 +110,10 @@ def move_well_annotations(conn, well, ann_type, remove_anns, ns):
     if remove_anns:
         log("Deleting ImageAnnotation links... %s" % link_ids)
         try:
-            for link_id in link_ids:
-                to_delete = ImageAnnotationLinkI(link_id, False)
-                conn.getUpdateService().deleteObject(to_delete)
+            delete = Delete2(targetObjects={'ImageAnnotationLink': link_ids})
+            handle = conn.c.sf.submit(delete)
+            conn.c.waitOnCmd(handle, loops=10, ms=500, failonerror=True,
+                             failontimeout=False, closehandle=False)
         except Exception, ex:
             log("Failed to delete links: %s" % ex.message)
     return len(new_links)

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -185,7 +185,7 @@ other users have added, creating links that belong to the same users.
 
         scripts.String(
             "Annotation_Type", grouping="3",
-            description="Move All annotations OR just one type of annotation",
+            description="Move all annotations OR just one type of annotation",
             values=ann_types, default='All'),
 
         scripts.String(

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -22,9 +22,8 @@
 import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 from omero.model import ExperimenterI, \
-                        ImageAnnotationLinkI, \
-                        WellAnnotationLinkI, \
-                        WellI
+    WellAnnotationLinkI, \
+    WellI
 from omero.cmd import Delete2
 from omero.sys import ParametersI, Filter
 from omero.rtypes import rstring, rlong, robject

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -186,5 +186,6 @@ def run_script():
     finally:
         client.closeSession()
 
+
 if __name__ == "__main__":
     run_script()

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -46,8 +46,9 @@ def move_well_annotations(conn, well, ann_type, remove_anns, ns):
     old_links = list(conn.getAnnotationLinks('Image', iids, ns=ns))
 
     # Filter by type
-    old_links = [l for l in old_links if (ann_type is None
-                            or (l.child.__class__.__name__ == ann_type))]
+    old_links = [l for l in old_links
+                 if (ann_type is None
+                     or (l.child.__class__.__name__ == ann_type))]
 
     link_ids = [l.id for l in old_links]
 
@@ -124,7 +125,7 @@ def move_annotations(conn, script_params):
     return ann_total
 
 
-def runScript():
+def run_script():
     """The main entry point of the script."""
     data_types = [rstring('Screen'), rstring('Plate'), rstring('Well')]
 
@@ -142,12 +143,12 @@ def runScript():
 
         scripts.List(
             "IDs", optional=False, grouping="2",
-            description="List of Screen IDs or Plate IDs").ofType(rlong(0)),
+            description="List of Screen, Plate or Well IDs").ofType(rlong(0)),
 
         scripts.String(
             "Annotation_Type", grouping="3",
-            description="Move All annotations OR just one type of annotation"
-            " Z below.", values=ann_types, default='All'),
+            description="Move All annotations OR just one type of annotation",
+            values=ann_types, default='All'),
 
         scripts.String(
             "Namespace", grouping="4",
@@ -186,4 +187,4 @@ def runScript():
         client.closeSession()
 
 if __name__ == "__main__":
-    runScript()
+    run_script()

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -34,6 +34,7 @@ ANN_TYPES = {
     'Key-Value': 'MapAnnotationI'
 }
 
+
 def log(text):
     """Handles logging statements in a single place."""
     print text

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Moves Annotations from Images to their parent Wells."""
+
+import omero.scripts as scripts
+from omero.gateway import BlitzGateway
+from omero.model import WellAnnotationLinkI, WellI, ImageAnnotationLinkI
+from omero.rtypes import rstring, rlong
+
+
+ANN_TYPES = {
+    'Tag': 'TagAnnotationI',
+    'File': 'FileAnnotationI',
+    'Comment': 'CommentAnnotationI',
+    'Rating': 'LongAnnotationI',
+    'Key-Value': 'MapAnnotationI'
+}
+
+
+def move_well_annotations(conn, well, ann_type, remove_anns, ns):
+    """Move annotations from Images in this Well onto the Well itself."""
+    print "Processing Well:", well.id, well.getWellPos()
+    iids = [wellSample.getImage().id for wellSample in well.listChildren()]
+    print "  Image IDs:", iids
+    if len(iids) == 0:
+        return 0
+
+    old_links = list(conn.getAnnotationLinks('Image', iids, ns=ns))
+
+    # Filter by type
+    old_links = [l for l in old_links if (ann_type is None
+                            or (l.child.__class__.__name__ == ann_type))]
+
+    link_ids = [l.id for l in old_links]
+
+    # Remove duplicate annotations
+    links_dict = {}
+    for l in old_links:
+        ann = l.child
+        links_dict[ann.id.val] = l
+    old_links = links_dict.values()
+
+    new_links = []
+    for l in old_links:
+        print "    Annotation:", l.child.id.val, l.child.__class__.__name__
+        link = WellAnnotationLinkI()
+        link.parent = WellI(well.id, False)
+        link.child = l.child
+        new_links.append(link)
+    try:
+        conn.getUpdateService().saveArray(new_links)
+    except Exception, ex:
+        print "Failed to create links: ", ex.message
+        return 0
+
+    if remove_anns:
+        print "Deleting ImageAnnotation links...", link_ids
+        try:
+            for link_id in link_ids:
+                to_delete = ImageAnnotationLinkI(link_id, False)
+                conn.getUpdateService().deleteObject(to_delete)
+        except Exception, ex:
+            print "Failed to delete links: ", ex.message
+    return len(new_links)
+
+
+def move_annotations(conn, script_params):
+    """Process script parameters and move annotations as specified."""
+    plates = []
+    filter_type = None
+
+    dtype = script_params['Data_Type']
+    ids = script_params['IDs']
+    ann_type = script_params['Annotation_Type']
+    if ann_type in ANN_TYPES:
+        filter_type = ANN_TYPES[ann_type]
+    remove_anns = script_params['Remove_Annotations']
+    ns = script_params.get('Namespace')
+
+    # Get the Plates or Wells
+    objects = conn.getObjects(dtype, ids)
+
+    ann_total = 0
+
+    if dtype == 'Well':
+        for well in objects:
+            ann_count = move_well_annotations(conn, well, filter_type,
+                                              remove_anns, ns)
+            ann_total += ann_count
+    else:
+        if dtype == 'Plate':
+            plates = list(objects)
+        elif dtype == 'Screen':
+            for screen in objects:
+                plates.extend(list(screen.listChildren()))
+        print "Found Plates:", plates
+        for plate in plates:
+            for well in plate.listChildren():
+                ann_count = move_well_annotations(conn, well, filter_type,
+                                                  remove_anns, ns)
+                ann_total += ann_count
+
+    return ann_total
+
+
+def runScript():
+    """The main entry point of the script."""
+    data_types = [rstring('Screen'), rstring('Plate'), rstring('Well')]
+
+    ann_types = [rstring('All')]
+    ann_types.extend([rstring(k) for k in ANN_TYPES.keys()])
+
+    client = scripts.client(
+        'Move_Annotations.py',
+        """Move Annotations from SPW Images to their parent Wells.""",
+
+        scripts.String(
+            "Data_Type", optional=False, grouping="1",
+            description="The data you want to work with.", values=data_types,
+            default="Plate"),
+
+        scripts.List(
+            "IDs", optional=False, grouping="2",
+            description="List of Screen IDs or Plate IDs").ofType(rlong(0)),
+
+        scripts.String(
+            "Annotation_Type", grouping="3",
+            description="Move All annotations OR just one type of annotation"
+            " Z below.", values=ann_types, default='All'),
+
+        scripts.String(
+            "Namespace", grouping="4",
+            description="Filter annotations by namespace"),
+
+        scripts.Bool(
+            "Remove_Annotations", grouping="5",
+            description="If false, annotations will remain linked to Images",
+            default=True),
+
+        version="5.3.0",
+        authors=["William Moore", "OME Team"],
+        institutions=["University of Dundee"],
+        contact="ome-users@lists.openmicroscopy.org.uk",
+    )
+
+    try:
+        conn = BlitzGateway(client_obj=client)
+
+        script_params = client.getInputs(unwrap=True)
+        print script_params
+
+        # call the main script
+        anns_moved = move_annotations(conn, script_params)
+
+        message = ""
+        # return 'Message' to client
+        if anns_moved is not None:
+            message = "Moved %s Annotations" % anns_moved
+        else:
+            message = "No annotations moved. See info."
+
+        client.setOutput("Message", rstring(message))
+
+    finally:
+        client.closeSession()
+
+if __name__ == "__main__":
+    runScript()

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -97,8 +97,8 @@ def move_well_annotations(conn, well, ann_type, remove_anns, ns):
         link.child = l.child
         # If Admin, the new link Owner is same as old link Owner
         if conn.isAdmin():
-            ownerId = l.details.owner.id.val
-            link.details.owner = ExperimenterI(ownerId, False)
+            owner_id = l.details.owner.id.val
+            link.details.owner = ExperimenterI(owner_id, False)
         new_links.append(link)
     try:
         conn.getUpdateService().saveArray(new_links)

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -193,9 +193,9 @@ other users have added, creating links that belong to the same users.
             description="Filter annotations by namespace"),
 
         scripts.Bool(
-            "Remove_Annotations", grouping="5",
+            "Remove_Annotations_From_Images", grouping="5",
             description="If false, annotations will remain linked to Images",
-            default=True),
+            default=False),
 
         version="5.3.0",
         authors=["William Moore", "OME Team"],


### PR DESCRIPTION
Script to Select Screens, Plates, or Wells and move Annotations from Images onto their parent Wells.
See https://trello.com/c/gasafKWk/291-update-script-wellsample-well-annotation-migration

To test:

- Add a bunch of Annotations to Images in Wells. Pick some Wells that have multiple fields.
     - Add tags, ratings, map annotations, comments etc. 
- Select Screens, Plates or Wells and run script (check that selected S/P/W are populated in dialog)
- Choose to filter annotations by Type or Namespace. (can test this using ```openmicroscopy.org/omero/client/mapAnnotation``` for Map Annotations).
- Test "Remove Annotations" removes annotations from Images if checked.

![screen shot 2017-03-03 at 14 59 17](https://cloud.githubusercontent.com/assets/900055/23556233/c6f45524-0023-11e7-9537-e4a09410e217.png)
