### PR TITLE
label_rotate_fix

### DIFF
--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -334,7 +334,7 @@ def add_left_labels(panel_canvas, image_labels, row_index, width, spacer):
     # add text to rows
     # want it to be vertical. Rotate and paste the text canvas from above
     if image_labels:
-        text_v = text_canvas.rotate(90)
+        text_v = text_canvas.rotate(90, expand=True)
         image_utils.paste_image(text_v, canvas, spacer/2, 0)
 
     return canvas

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -439,7 +439,7 @@ def make_split_view_figure(conn, pixel_ids, z_start, z_end, split_indexes,
     # add text to rows
     # want it to be vertical. Rotate and paste the text canvas from above
     if image_labels:
-        text_v = text_canvas.rotate(90)
+        text_v = text_canvas.rotate(90, expand=True)
         image_utils.paste_image(text_v, canvas, spacer, top_text_height)
 
     # add text to columns


### PR DESCRIPTION
See https://trello.com/c/rE4VXlX1/33-figure-scripts-rotate-labels-bug
Fixes bug in rotation of labels for figure scripts, previously fixed in OMERO.figure https://github.com/ome/omero-figure/pull/140/files and reported at https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8303

To test, create a Split_View_Figure with the script, and check the vertical labels.
Before and after screenshot:

![screen shot 2017-06-22 at 11 59 42](https://user-images.githubusercontent.com/900055/27431026-d3a79594-5742-11e7-87b7-1adc63651652.png)
