### PR TITLE
images from ROIs all ZT planes

### DIFF
--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -231,7 +231,10 @@ def process_image(conn, image_id, parameter_map):
             for r in rois:
                 x, y, w, h, z1, z2, t1, t2 = r
                 tile = (x, y, width, height)
-                zct_tile_list.append((z1, c, t1, tile))
+                theZ = z1 if z1 is not None else 0
+                theT = t1 if t1 is not None else 0
+                zct_tile_list.append((theZ, c, theT, tile))
+            print 'image_stack zct_tile_list:', zct_tile_list
             for t in pixels.getTiles(zct_tile_list):
                 yield t
 

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -231,9 +231,9 @@ def process_image(conn, image_id, parameter_map):
             for r in rois:
                 x, y, w, h, z1, z2, t1, t2 = r
                 tile = (x, y, width, height)
-                theZ = z1 if z1 is not None else 0
-                theT = t1 if t1 is not None else 0
-                zct_tile_list.append((theZ, c, theT, tile))
+                the_z = z1 if z1 is not None else 0
+                the_t = t1 if t1 is not None else 0
+                zct_tile_list.append((the_z, c, the_t, tile))
             print 'image_stack zct_tile_list:', zct_tile_list
             for t in pixels.getTiles(zct_tile_list):
                 yield t

--- a/test/integration/test_util_scripts.py
+++ b/test/integration/test_util_scripts.py
@@ -83,7 +83,7 @@ class TestUtilScripts(ScriptTest):
         assert combine_img is not None
         assert combine_img.getValue().id.val > 0
 
-@pytest.mark.parametrize("imageStack", [True, False])
+    @pytest.mark.parametrize("imageStack", [True, False])
     def test_images_from_rois(self, imageStack):
         script_id = super(TestUtilScripts, self).get_script(images_from_rois)
         assert script_id > 0
@@ -94,7 +94,7 @@ class TestUtilScripts(ScriptTest):
         size_x = 100
         size_y = 100
         size_z = 5
-        image = self.create_test_image(size_x, size_y, size_z, 1, 1)    # x,y,z,c,t
+        image = self.create_test_image(size_x, size_y, size_z, 1, 1)
         image_id = image.id.val
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image_id))

--- a/test/integration/test_util_scripts.py
+++ b/test/integration/test_util_scripts.py
@@ -83,8 +83,8 @@ class TestUtilScripts(ScriptTest):
         assert combine_img is not None
         assert combine_img.getValue().id.val > 0
 
-    @pytest.mark.parametrize("imageStack", [True, False])
-    def test_images_from_rois(self, imageStack):
+    @pytest.mark.parametrize("image_stack", [True, False])
+    def test_images_from_rois(self, image_stack):
         script_id = super(TestUtilScripts, self).get_script(images_from_rois)
         assert script_id > 0
         # root session is root.sf
@@ -112,7 +112,7 @@ class TestUtilScripts(ScriptTest):
         args = {
             "Data_Type": omero.rtypes.rstring("Image"),
             "IDs": omero.rtypes.rlist(image_ids),
-            "Make_Image_Stack": omero.rtypes.rbool(imageStack)
+            "Make_Image_Stack": omero.rtypes.rbool(image_stack)
         }
         img_from_rois = run_script(client, script_id, args, "Result")
         # check the result
@@ -121,7 +121,7 @@ class TestUtilScripts(ScriptTest):
         new_size_z = new_img.getPrimaryPixels().getSizeZ().getValue()
         # From a single ROI (without theZ) on Z-stack image...
         # Should get a single Z image from single ROI if Make_Image_Stack
-        if imageStack:
+        if image_stack:
             assert new_size_z == 1
         else:
             # Otherwise we use all planes of input image

--- a/test/integration/test_util_scripts.py
+++ b/test/integration/test_util_scripts.py
@@ -83,7 +83,8 @@ class TestUtilScripts(ScriptTest):
         assert combine_img is not None
         assert combine_img.getValue().id.val > 0
 
-    def test_images_from_rois(self):
+@pytest.mark.parametrize("imageStack", [True, False])
+    def test_images_from_rois(self, imageStack):
         script_id = super(TestUtilScripts, self).get_script(images_from_rois)
         assert script_id > 0
         # root session is root.sf
@@ -92,7 +93,8 @@ class TestUtilScripts(ScriptTest):
 
         size_x = 100
         size_y = 100
-        image = self.create_test_image(size_x, size_y, 5, 1, 1)    # x,y,z,c,t
+        size_z = 5
+        image = self.create_test_image(size_x, size_y, size_z, 1, 1)    # x,y,z,c,t
         image_id = image.id.val
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image_id))
@@ -110,12 +112,20 @@ class TestUtilScripts(ScriptTest):
         args = {
             "Data_Type": omero.rtypes.rstring("Image"),
             "IDs": omero.rtypes.rlist(image_ids),
-            "Make_Image_Stack": omero.rtypes.rbool(True)
+            "Make_Image_Stack": omero.rtypes.rbool(imageStack)
         }
         img_from_rois = run_script(client, script_id, args, "Result")
         # check the result
         assert img_from_rois is not None
-        assert img_from_rois.getValue().id.val > 0
+        new_img = img_from_rois.getValue()
+        new_size_z = new_img.getPrimaryPixels().getSizeZ().getValue()
+        # From a single ROI (without theZ) on Z-stack image...
+        # Should get a single Z image from single ROI if Make_Image_Stack
+        if imageStack:
+            assert new_size_z == 1
+        else:
+            # Otherwise we use all planes of input image
+            assert new_size_z == size_z
 
     def test_dataset_to_plate(self):
         script_id = super(TestUtilScripts, self).get_script(dataset_to_plate)


### PR DESCRIPTION
See https://trello.com/c/my7BGCEb/7-crop-iviewer-and-images-from-rois

This supports cropping a multi-Z or multi-T image to create a new image with the same number of Z or T planes.
This was supported before, but needed a multi-shape ROI with shapes on all the Z/T planes to be included.
Now, if an ROI has no Z set on its shape(s) then we use all Z planes. Same for T.
To test:

 - Using an image with multiple Z and T, create several rectangles, some with Z and T set, some with no Z or T set. See all combinations in screenshot.
 - Run the Images from ROIs on the image.
 - If a shape has no Z set, we create new image with all Z planes, same for T.
 - For screenshot below, we created 1 single-plane image, 1 single-Z timelapse, 1 single-T z-stack and 1 image of same Z and T size as original.
 
<img width="567" alt="screen shot 2017-12-12 at 16 36 28" src="https://user-images.githubusercontent.com/900055/33896439-b9b50acc-df5a-11e7-8771-c393b1db040c.png">

