### PR TITLE
batch export ROIs

### DIFF
--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -195,7 +195,7 @@ def run_script():
 
         scripts.List(
             "Channels", grouping="3", default=[1L, 2L, 3L, 4L],
-            description="Indecies of Channels to measure intensity."
+            description="Indices of Channels to measure intensity."
             ).ofType(rlong(0)),
 
         scripts.Bool(

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -200,7 +200,8 @@ def run_script():
 
         scripts.Bool(
             "Export_All_Planes", grouping="4",
-            description="Export all Z and T planes for shapes without Z / T?",
+            description=("Export all Z and T planes for shapes "
+                         "where Z and T are not set?"),
             default=False),
 
         scripts.String(

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -52,6 +52,9 @@ def get_export_data(conn, script_params, image):
 
     ch_names = image.getChannelLabels()
 
+    ch_names = [ch_name.replace(",", ".") for ch_name in ch_names]
+    image_name = image.getName().replace(",", ".")
+
     result = roi_service.findByImage(image.getId(), None)
 
     export_data = []
@@ -60,7 +63,7 @@ def get_export_data(conn, script_params, image):
         for shape in roi.copyShapes():
             label = unwrap(shape.getTextValue())
             # wrap label in double quotes in case it contains comma
-            label = "" if label is None else '"%s"' % label
+            label = "" if label is None else '"%s"' % label.replace(",", ".")
             shape_type = shape.__class__.__name__.rstrip('I').lower()
             # If shape has no Z or T, we may go through all planes...
             the_z = unwrap(shape.theZ)
@@ -84,7 +87,7 @@ def get_export_data(conn, script_params, image):
                     for c, ch_index in enumerate(ch_indexes):
                         export_data.append({
                             "image_id": image.getId(),
-                            "image_name": '"%s"' % image.getName(),
+                            "image_name": '"%s"' % image_name,
                             "roi_id": roi.id.val,
                             "shape_id": shape.id.val,
                             "type": shape_type,

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -194,7 +194,7 @@ def run_script():
             description="List of Dataset IDs or Image IDs").ofType(rlong(0)),
 
         scripts.List(
-            "Channels", grouping="3", default=[1L,2L,3L,4L],
+            "Channels", grouping="3", default=[1L, 2L, 3L, 4L],
             description="Indecies of Channels to measure intensity."
             ).ofType(rlong(0)),
 

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -61,7 +61,7 @@ def get_export_data(conn, script_params, image):
             label = unwrap(shape.getTextValue())
             # wrap label in double quotes in case it contains comma
             label = "" if label is None else '"%s"' % label
-            shape_type = shape.__class__.__name__.rstrip('I')
+            shape_type = shape.__class__.__name__.rstrip('I').lower()
             # If shape has no Z or T, we may go through all planes...
             the_z = unwrap(shape.theZ)
             z_indexes = [the_z]
@@ -83,40 +83,40 @@ def get_export_data(conn, script_params, image):
                             [shape.id.val], z, t, ch_indexes)
                     for c, ch_index in enumerate(ch_indexes):
                         export_data.append({
-                            "Image ID": image.getId(),
-                            "Image Name": '"%s"' % image.getName(),
-                            "ROI ID": roi.id.val,
-                            "Shape ID": shape.id.val,
-                            "Shape": shape_type,
-                            "Label": label,
-                            "Z": z + 1 if z is not None else "",
-                            "T": t + 1 if t is not None else "",
-                            "Channel": ch_names[ch_index],
-                            "Points": stats[0].pointsCount[c] if stats else "",
-                            "Min": stats[0].min[c] if stats else "",
-                            "Max": stats[0].max[c] if stats else "",
-                            "Sum": stats[0].sum[c] if stats else "",
-                            "Mean": stats[0].mean[c] if stats else "",
-                            "Std dev": stats[0].stdDev[c] if stats else ""
+                            "image_id": image.getId(),
+                            "image_name": '"%s"' % image.getName(),
+                            "roi_id": roi.id.val,
+                            "shape_id": shape.id.val,
+                            "type": shape_type,
+                            "text": label,
+                            "z": z + 1 if z is not None else "",
+                            "t": t + 1 if t is not None else "",
+                            "channel": ch_names[ch_index],
+                            "points": stats[0].pointsCount[c] if stats else "",
+                            "min": stats[0].min[c] if stats else "",
+                            "max": stats[0].max[c] if stats else "",
+                            "sum": stats[0].sum[c] if stats else "",
+                            "mean": stats[0].mean[c] if stats else "",
+                            "std_dev": stats[0].stdDev[c] if stats else ""
                         })
     return export_data
 
 
-COLUMN_NAMES = ["Image ID",
-                "Image Name",
-                "ROI ID",
-                "Shape ID",
-                "Shape",
-                "Label",
-                "Z",
-                "T",
-                "Channel",
-                "Points",
-                "Min",
-                "Max",
-                "Sum",
-                "Mean",
-                "Std dev"]
+COLUMN_NAMES = ["image_id",
+                "image_name",
+                "roi_id",
+                "shape_id",
+                "type",
+                "text",
+                "z",
+                "t",
+                "channel",
+                "points",
+                "min",
+                "max",
+                "sum",
+                "mean",
+                "std_dev"]
 
 
 def write_csv(conn, export_data, script_params):

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -194,7 +194,7 @@ def run_script():
             description="List of Dataset IDs or Image IDs").ofType(rlong(0)),
 
         scripts.List(
-            "Channels", grouping="3",
+            "Channels", grouping="3", default=[1L,2L,3L,4L],
             description="Indecies of Channels to measure intensity."
             ).ofType(rlong(0)),
 

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -141,11 +141,11 @@ def write_csv(conn, export_data, script_params):
     return conn.createFileAnnfromLocalFile(file_name, mimetype="text/csv")
 
 
-def link_images(images, file_ann):
-    """Link the File Annotation to each image."""
-    for i in images:
-        if i.canAnnotate():
-            i.linkAnnotation(file_ann)
+def link_annotation(objects, file_ann):
+    """Link the File Annotation to each object."""
+    for o in objects:
+        if o.canAnnotate():
+            o.linkAnnotation(file_ann)
 
 
 def batch_roi_export(conn, script_params):
@@ -169,7 +169,11 @@ def batch_roi_export(conn, script_params):
 
     # Write to csv
     file_ann = write_csv(conn, export_data, script_params)
-    link_images(images, file_ann)
+    if script_params['Data_Type'] == "Dataset":
+        datasets = conn.getObjects("Dataset", script_params['IDs'])
+        link_annotation(datasets, file_ann)
+    else:
+        link_annotation(images, file_ann)
     message = "Exported %s shapes" % len(export_data)
     return file_ann, message
 

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -82,7 +82,6 @@ def get_export_data(conn, script_params, image):
                         stats = roi_service.getShapeStatsRestricted(
                             [shape.id.val], z, t, ch_indexes)
                     for c, ch_index in enumerate(ch_indexes):
-                        # ch_index = stats[0].channelIds[c]
                         export_data.append({
                             "Image ID": image.getId(),
                             "Image Name": '"%s"' % image.getName(),

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# -----------------------------------------------------------------------------
+#   Copyright (C) 2018 University of Dundee. All rights reserved.
+
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# ------------------------------------------------------------------------------
+
+"""This script exports ROI intensities for selected images."""
+
+
+import omero.scripts as scripts
+from omero.gateway import BlitzGateway
+from omero.rtypes import unwrap, rstring, rlong, robject
+
+DEFAULT_FILE_NAME = "roi_intensities.csv"
+
+def get_export_data(conn, script_params, image):
+    """Get pixel data for shapes on image and returns list of dicts."""
+    roi_service = conn.getRoiService()
+    all_planes = script_params["Export_All_Planes"]
+    channels = script_params.get("Channels", [1])
+    ch_names = image.getChannelLabels()
+
+    result = roi_service.findByImage(image.getId(), None)
+
+    export_data = []
+
+    for roi in result.rois:
+        for shape in roi.copyShapes():
+            label = unwrap(shape.getTextValue())
+            label = "" if label is None else label
+            shape_type = shape.__class__.__name__.rstrip('I')
+            # If shape has no Z or T, we may go through all planes...
+            the_z = unwrap(shape.theZ)
+            if the_z is not None:
+                z_indexes = [the_z]
+            elif all_planes:
+                z_indexes = range(image.getSizeZ())
+            else:
+                z_indexes = [image.getDefaultZ()]
+            # Same for T...
+            the_t = unwrap(shape.theT)
+            if the_t is not None:
+                t_indexes = [the_t]
+            elif all_planes:
+                t_indexes = range(image.getSizeT())
+            else:
+                t_indexes = [image.getDefaultT()]
+
+            # get pixel intensities
+            for z in z_indexes:
+                for t in t_indexes:
+                    stats = roi_service.getShapeStatsRestricted([shape.id.val],
+                                                                z, t,
+                                                                channels)
+                    for ch_index in channels:
+                        c = ch_index - 1    # User input is 1-based
+                        export_data.append({
+                            "Image ID": image.getId(),
+                            "Image Name": image.getName(),
+                            "ROI ID": roi.id.val,
+                            "Shape ID": shape.id.val,
+                            "Shape": shape_type,
+                            "Label": label,
+                            "Z": z,
+                            "T": t,
+                            "C": c,
+                            "Channel": ch_names[c],
+                            "Points": stats[0].pointsCount[c],
+                            "Min": stats[0].min[c],
+                            "Max": stats[0].max[c],
+                            "Sum": stats[0].sum[c],
+                            "Mean": stats[0].mean[c],
+                            "Std dev": stats[0].stdDev[c]
+                        })
+    return export_data
+
+
+COLUMN_NAMES = ["Image ID",
+                "Image Name",
+                "ROI ID",
+                "Shape ID",
+                "Shape",
+                "Label",
+                "Z",
+                "T",
+                "C",
+                "Channel",
+                "Points",
+                "Min",
+                "Max",
+                "Sum",
+                "Mean",
+                "Std dev"]
+
+
+def write_csv(conn, export_data, script_params):
+    """Write the list of data to a csv file & create file annotation."""
+    file_name = script_params.get("File_Name", "")
+    if len(file_name) == 0:
+        file_name = DEFAULT_FILE_NAME
+    if not file_name.endswith(".csv"):
+        file_name += ".csv"
+
+    csv_rows = [",".join(COLUMN_NAMES)]
+    for row in export_data:
+        cells = [str(row.get(name)) for name in COLUMN_NAMES]
+        csv_rows.append(",".join(cells))
+
+    with open(file_name, 'w') as csv_file:
+        csv_file.write("\n".join(csv_rows))
+
+    file_ann = conn.createFileAnnfromLocalFile(file_name,
+                                               mimetype="text/csv")
+    return file_ann
+
+
+def batch_roi_export(conn, script_params):
+    """Main entry point. Get images, process them and return result."""
+    images = []
+
+    if script_params['Data_Type'] == "Image":
+        images = list(conn.getObjects("Image", script_params['IDs']))
+    else:
+        for dataset in conn.getObjects("Dataset", script_params['IDs']):
+            images.extend(list(dataset.listChildren()))
+
+    print "Processing %s images..." % len(images)
+    if len(images) == 0:
+        return None
+
+    # build a list of dicts.
+    export_data = []
+    for image in images:
+        export_data.extend(get_export_data(conn, script_params, image))
+
+    # Write to csv
+    file_ann = write_csv(conn, export_data, script_params)
+    message = "Exported %s shapes" % len(export_data)
+    return file_ann, message
+
+
+def run_script():
+    """The main entry point of the script, as called by the client."""
+    data_types = [rstring('Dataset'), rstring('Image')]
+
+    client = scripts.client(
+        'Batch_ROI_Export.py',
+        """Export ROI intensities for selected Images""",
+
+        scripts.String(
+            "Data_Type", optional=False, grouping="1",
+            description="The data you want to work with.", values=data_types,
+            default="Image"),
+
+        scripts.List(
+            "IDs", optional=False, grouping="2",
+            description="List of Dataset IDs or Image IDs").ofType(rlong(0)),
+
+        scripts.List(
+            "Channels", grouping="3",
+            description="Indecies of Channels to measure intensity."
+            ).ofType(rlong(0)),
+
+        scripts.Bool(
+            "Export_All_Planes", grouping="4",
+            description="Export all Z and T planes for shapes without Z / T?",
+            default=False),
+
+        scripts.String(
+            "File_Name", grouping="5", default=DEFAULT_FILE_NAME,
+            description="Name of the exported csv file"),
+
+        authors=["William Moore", "OME Team"],
+        institutions=["University of Dundee"],
+        contact="ome-users@lists.openmicroscopy.org.uk",
+    )
+
+    try:
+        conn = BlitzGateway(client_obj=client)
+
+        script_params = client.getInputs(unwrap=True)
+        print "script_params", script_params
+
+        # call the main script
+        result = batch_roi_export(conn, script_params)
+
+        # Return message and file_annotation to client
+        if result is None:
+            message = "No images found"
+        else:
+            file_ann, message = result
+            client.setOutput("File_Annotation", robject(file_ann._obj))
+
+        client.setOutput("Message", rstring(message))
+
+    finally:
+        client.closeSession()
+
+
+if __name__ == "__main__":
+    run_script()

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -28,6 +28,7 @@ from omero.rtypes import unwrap, rstring, rlong, robject
 
 DEFAULT_FILE_NAME = "roi_intensities.csv"
 
+
 def get_export_data(conn, script_params, image):
     """Get pixel data for shapes on image and returns list of dicts."""
     roi_service = conn.getRoiService()

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -123,7 +123,7 @@ COLUMN_NAMES = ["image_id",
 
 
 def write_csv(conn, export_data, script_params):
-    """Write the list of data to a CSV file & create file annotation."""
+    """Write the list of data to a CSV file and create a file annotation."""
     file_name = script_params.get("File_Name", "")
     if len(file_name) == 0:
         file_name = DEFAULT_FILE_NAME

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -227,7 +227,8 @@ def run_script():
             message = "No images found"
         else:
             file_ann, message = result
-            client.setOutput("File_Annotation", robject(file_ann._obj))
+            if file_ann is not None:
+                client.setOutput("File_Annotation", robject(file_ann._obj))
 
         client.setOutput("Message", rstring(message))
 

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -123,7 +123,7 @@ COLUMN_NAMES = ["image_id",
 
 
 def write_csv(conn, export_data, script_params):
-    """Write the list of data to a csv file & create file annotation."""
+    """Write the list of data to a CSV file & create file annotation."""
     file_name = script_params.get("File_Name", "")
     if len(file_name) == 0:
         file_name = DEFAULT_FILE_NAME
@@ -182,7 +182,7 @@ def run_script():
 
     client = scripts.client(
         'Batch_ROI_Export.py',
-        """Export ROI intensities for selected Images""",
+        """Export ROI intensities for selected Images as a CSV file.""",
 
         scripts.String(
             "Data_Type", optional=False, grouping="1",
@@ -206,7 +206,7 @@ def run_script():
 
         scripts.String(
             "File_Name", grouping="5", default=DEFAULT_FILE_NAME,
-            description="Name of the exported csv file"),
+            description="Name of the exported CSV file"),
 
         authors=["William Moore", "OME Team"],
         institutions=["University of Dundee"],

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -138,9 +138,7 @@ def write_csv(conn, export_data, script_params):
     with open(file_name, 'w') as csv_file:
         csv_file.write("\n".join(csv_rows))
 
-    file_ann = conn.createFileAnnfromLocalFile(file_name,
-                                               mimetype="text/csv")
-    return file_ann
+    return conn.createFileAnnfromLocalFile(file_name, mimetype="text/csv")
 
 
 def link_images(images, file_ann):

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -90,8 +90,8 @@ def get_export_data(conn, script_params, image):
                             "Shape ID": shape.id.val,
                             "Shape": shape_type,
                             "Label": label,
-                            "Z": z + 1,
-                            "T": t + 1,
+                            "Z": z + 1 if z is not None else "",
+                            "T": t + 1 if t is not None else "",
                             "Channel": ch_names[ch_index],
                             "Points": stats[0].pointsCount[c] if stats else "",
                             "Min": stats[0].min[c] if stats else "",
@@ -141,6 +141,13 @@ def write_csv(conn, export_data, script_params):
     return file_ann
 
 
+def link_images(images, file_ann):
+    """Link the File Annotation to each image."""
+    for i in images:
+        if i.canAnnotate():
+            i.linkAnnotation(file_ann)
+
+
 def batch_roi_export(conn, script_params):
     """Main entry point. Get images, process them and return result."""
     images = []
@@ -162,6 +169,7 @@ def batch_roi_export(conn, script_params):
 
     # Write to csv
     file_ann = write_csv(conn, export_data, script_params)
+    link_images(images, file_ann)
     message = "Exported %s shapes" % len(export_data)
     return file_ann, message
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ class PyTest(test_command):
         ('test-no-capture', 's', "don't suppress test output"),
         ('test-failfast', 'x', "Exit on first error"),
         ('test-verbose', 'v', "more verbose output"),
+        ('test-string=', 'k', "filter tests by string"),
         ('test-quiet', 'q', "less verbose output"),
         ('junitxml=', None, "create junit-xml style report file at 'path'"),
         ('pdb', None, "fallback to pdb on error"),

--- a/test/integration/script.py
+++ b/test/integration/script.py
@@ -107,7 +107,8 @@ def points_to_string(points):
 
 
 def check_file_annotation(client, file_annotation,
-                          parent_type="Image", is_linked=True):
+                          parent_type="Image", is_linked=True,
+                          file_name=None):
     """
     Check validity of file annotation. If hasFileAnnotation, check the size,
     name and number of objects linked to the original file.
@@ -123,8 +124,21 @@ def check_file_annotation(client, file_annotation,
 
     wrapper = conn.getObject("FileAnnotation", id)
     links = sum(1 for i in wrapper.getParentLinks(parent_type))
-    conn.close()
     if is_linked:
         assert links == 1
     else:
         assert links == 0
+
+    if file_name is not None:
+        name = wrapper.getFile().getName()
+        assert name == file_name
+    conn.close()
+
+
+def get_file_contents(client, original_file_id):
+    """Returns Original File contents as a string."""
+    conn = BlitzGateway(client_obj=client)
+    orig_file = conn.getObject("OriginalFile", original_file_id)
+    text = "".join(orig_file.getFileInChunks())
+    conn.close()
+    return text

--- a/test/integration/test_export_scripts.py
+++ b/test/integration/test_export_scripts.py
@@ -125,9 +125,9 @@ class TestExportScripts(ScriptTest):
         if all_planes:
             zt = "1,1"
             points_min_max_sum_mean = "6561,10.0,90.0,328050.0,50.0"
-        expected = ("Image ID,Image Name,ROI ID,Shape ID,Shape,Label,"
-                    "Z,T,Channel,Points,Min,Max,Sum,Mean,Std dev\n"
-                    "%s,\"%s\",%s,%s,Polygon,\"%s\",%s,0,%s,") % (
+        expected = ("image_id,image_name,roi_id,shape_id,type,text,"
+                    "z,t,channel,points,min,max,sum,mean,std_dev\n"
+                    "%s,\"%s\",%s,%s,polygon,\"%s\",%s,0,%s,") % (
                     image.id.val, image_name, roi.id.val,
                     polygon.id.val, label_text, zt, points_min_max_sum_mean)
         assert csv_text.startswith(expected)

--- a/test/integration/test_export_scripts.py
+++ b/test/integration/test_export_scripts.py
@@ -29,9 +29,12 @@ import omero.scripts
 from script import ScriptTest
 from script import run_script
 from script import check_file_annotation
+from script import get_file_contents
+from omero.rtypes import rstring, rint, rlong, rlist, rdouble, rbool
 
 
 batch_image_export = "/omero/export_scripts/Batch_Image_Export.py"
+batch_roi_export = "/omero/export_scripts/Batch_ROI_Export.py"
 make_movie = "/omero/export_scripts/Make_Movie.py"
 
 
@@ -45,14 +48,89 @@ class TestExportScripts(ScriptTest):
         # x,y,z,c,t
         image = self.create_test_image(100, 100, 1, 1, 1, client.getSession())
         image_ids = []
-        image_ids.append(omero.rtypes.rlong(image.id.val))
+        image_ids.append(rlong(image.id.val))
         args = {
-            "Data_Type": omero.rtypes.rstring("Image"),
-            "IDs": omero.rtypes.rlist(image_ids)
+            "Data_Type": rstring("Image"),
+            "IDs": rlist(image_ids)
         }
         ann = run_script(client, sid, args, "File_Annotation")
         c = self.new_client(user=user)
         check_file_annotation(c, ann)
+
+    @pytest.mark.parametrize("all_planes", [True, False])
+    def test_batch_roi_export(self, all_planes):
+        sid = super(TestExportScripts, self).get_script(batch_roi_export)
+        assert sid > 0
+
+        client, user = self.new_client_and_user()
+        session = client.getSession()
+        # x,y,z,c,t
+        size_c = 2
+        size_z = 3
+        size_t = 4
+        image_name = "ROI_image"
+        label_text = "Shape_Text"
+        image = self.create_test_image(100, 100, size_z, size_c, size_t,
+                                       session, name=image_name)
+        # Add 2 Shapes... A Rectangle and Polygon covering same area
+        polygon = omero.model.PolygonI()
+        polygon.points = rstring("10,10, 91,10, 91,91, 10,91")
+        polygon.textValue = rstring(label_text)
+        rect = omero.model.RectangleI()
+        rect.x = rdouble(10)
+        rect.y = rdouble(10)
+        rect.width = rdouble(81)
+        rect.height = rdouble(81)
+        rect.theZ = rint(1)
+        rect.theT = rint(1)
+        # ...to an ROI
+        roi = omero.model.RoiI()
+        roi.setImage(image)
+        roi.addShape(polygon)
+        roi.addShape(rect)
+        roi = session.getUpdateService().saveAndReturnObject(roi)
+        shapes = roi.copyShapes()
+        polygon = shapes[0]
+
+        image_ids = []
+        file_name = "test_batch_roi_export"
+        image_ids.append(rlong(image.id.val))
+        channels = [rlong(c) for c in range(4)]
+        args = {
+            "Data_Type": rstring("Image"),
+            "IDs": rlist(image_ids),
+            # Should ignore Channels out of range. 1-based index
+            "Channels": rlist(channels),
+            "Export_All_Planes": rbool(all_planes),
+            "File_Name": rstring(file_name)
+        }
+        ann = run_script(client, sid, args, "File_Annotation")
+        c = self.new_client(user=user)
+        check_file_annotation(c, ann,
+                              file_name="%s.csv" % file_name)
+        file_id = ann.getValue().getFile().id.val
+        csv_text = get_file_contents(self.new_client(user=user), file_id)
+
+        # Check we have expected number of rows
+        polygon_planes = size_c
+        if all_planes:
+            polygon_planes = size_c * size_z * size_t
+        # Rows: Header + rect with Z/T set + polygon without Z/T
+        row_count = 1 + size_c + polygon_planes
+        assert len(csv_text.split("\n")) == row_count
+
+        # Check first 2 rows of csv (except Std dev)
+        zt = ","
+        points_min_max_sum_mean = ",,,,"
+        if all_planes:
+            zt = "1,1"
+            points_min_max_sum_mean = "6561,10.0,90.0,328050.0,50.0"
+        expected = ("Image ID,Image Name,ROI ID,Shape ID,Shape,Label,"
+                    "Z,T,Channel,Points,Min,Max,Sum,Mean,Std dev\n"
+                    "%s,\"%s\",%s,%s,Polygon,\"%s\",%s,0,%s,") % (
+                    image.id.val, image_name, roi.id.val,
+                    polygon.id.val, label_text, zt, points_min_max_sum_mean)
+        assert csv_text.startswith(expected)
 
     @pytest.mark.broken(
         reason=('https://trello.com/c/AlN5hp6g/144-make-movie-tests-failures'))
@@ -66,11 +144,11 @@ class TestExportScripts(ScriptTest):
         # x,y,z,c,t
         image = self.create_test_image(10, 10, 2, 1, 2, client.getSession())
         image_ids = []
-        image_ids.append(omero.rtypes.rlong(image.id.val))
+        image_ids.append(rlong(image.id.val))
         args = {
-            "Data_Type": omero.rtypes.rstring("Image"),
-            "IDs": omero.rtypes.rlist(image_ids),
-            "Movie_Name": omero.rtypes.rstring("test_make_movie")
+            "Data_Type": rstring("Image"),
+            "IDs": rlist(image_ids),
+            "Movie_Name": rstring("test_make_movie")
         }
         ann = run_script(client, script_id, args, "File_Annotation")
         c = self.new_client(user=user)


### PR DESCRIPTION
See https://trello.com/c/L6ue1oKe/115-rfe-roi-analysis

Provides ability to export ROI intensities from many images in a single csv file.
To test:

 - Draw shapes on images in iviewer (including some with Z and T null).
 - Also draw some in Insight, with multiple shapes per ROI
 - Select Images or parent Dataset and run script -> ```Export scripts -> Batch ROI Export```
 - Enter Channels to export, e.g. ```1,2``` for first 2 channels or just ```1``` (default)
 - Choose to export all Z/T planes for Shapes with no Z/T set. If true, shape will be 'propagated' to all Z/T when Z/T is not set for a shape. If false, we use the images default Z/T index for these shapes.
 - Should get a csv file returned from the script to download (and attached to all images) - Csv file is similar to that exported from iviewer. Same column names but a couple missing - e.g. area.

cc @waxenegger @pwalczysko 

<img width="506" alt="screen shot 2018-01-30 at 23 23 51" src="https://user-images.githubusercontent.com/900055/35597471-88b4222c-0616-11e8-8d18-40bc10a500f7.png">


