### PR TITLE
Kymograph points string float

### DIFF
--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -201,8 +201,7 @@ def polyline_kymograph(conn, script_params, image, polylines, line_width,
                     x1, y1 = points[l]
                     x2, y2 = points[l+1]
                     ld = get_line_data(image, x1, y1, x2, y2,
-                                          line_width, the_z, the_c,
-                                          the_t)
+                                       line_width, the_z, the_c, the_t)
                     line_data.append(ld)
                 row_data = hstack(line_data)
                 t_rows.append(row_data)

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -156,7 +156,7 @@ def points_string_to_xy_list(string):
     xy_list = []
     for xy in first_list.strip(" []").split(", "):
         x, y = xy.split(",")
-        xy_list.append((int(x.strip()), int(y.strip())))
+        xy_list.append((float(x.strip()), float(y.strip())))
     return xy_list
 
 

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -67,10 +67,10 @@ def get_line_data(image, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):
     size_x = image.getSizeX()
     size_y = image.getSizeY()
 
-    line_x = x2-x1
-    line_y = y2-y1
+    line_x = x2 - x1
+    line_y = y2 - y1
 
-    rads = math.atan(float(line_x)/line_y)
+    rads = math.atan2(line_y, line_x)
 
     # How much extra Height do we need, top and bottom?
     extra_h = abs(math.sin(rads) * line_w)
@@ -116,10 +116,8 @@ def get_line_data(image, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):
         pil = canvas
 
     # Now need to rotate so that x1,y1 is horizontally to the left of x2,y2
-    to_rotate = 90 - math.degrees(rads)
+    to_rotate = math.degrees(rads)
 
-    if x1 > x2:
-        to_rotate += 180
     # filter=Image.BICUBIC see
     # http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2172449/
     rotated = pil.rotate(to_rotate, expand=True)
@@ -206,7 +204,6 @@ def polyline_kymograph(conn, script_params, image, polylines, line_width,
                                           line_width, the_z, the_c,
                                           the_t)
                     line_data.append(ld)
-                line_data.reverse()
                 row_data = hstack(line_data)
                 t_rows.append(row_data)
 

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -30,7 +30,7 @@ sizeC as input.
 
 # @author Will Moore
 # <a href="mailto:will@lifesci.dundee.ac.uk">will@lifesci.dundee.ac.uk</a>
-# @version 4.3.3
+# @version 5.5.0
 # @since 3.0
 
 

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -112,6 +112,7 @@ def polyline_kymograph(conn, script_params, image, polylines, line_width,
                                                  line_width, the_z, the_c,
                                                  the_t)
                     line_data.append(ld)
+                line_data.reverse()
                 row_data = hstack(line_data)
                 t_rows.append(row_data)
 

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -37,6 +37,7 @@ sizeC as input.
 from omero.gateway import BlitzGateway
 import omero
 import omero.util.script_utils as script_utils
+import omero.util.roi_handling_utils as roi_utils
 from omero.rtypes import rlong, rstring, robject, unwrap
 import omero.scripts as scripts
 from numpy import zeros, hstack, vstack, asarray, math
@@ -135,29 +136,6 @@ def get_line_data(image, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):
     rgb_plane = asarray(cropped)
     # greyscale image. r, g, b all same. Just use first
     return rgb_plane[::, ::, 0]
-
-
-def points_string_to_xy_list(string):
-    """
-    Convert string to list of (x,y) points.
-
-    Expects string in format generated from omero.model.ShapeI.getPoints()
-    e.g. "points[309,427, 366,503]" to [(309,427), (366,503)]
-    """
-    point_lists = string.strip().split("points")
-    if len(point_lists) < 2:
-        if len(point_lists) == 1 and point_lists[0]:
-            xys = point_lists[0].split()
-            xy_list = [tuple(map(float, xy.split(','))) for xy in xys]
-            return xy_list
-        raise ValueError("Unrecognised ROI shape 'points' string: %s" % string)
-
-    first_list = point_lists[1]
-    xy_list = []
-    for xy in first_list.strip(" []").split(", "):
-        x, y = xy.split(",")
-        xy_list.append((float(x.strip()), float(y.strip())))
-    return xy_list
 
 
 def polyline_kymograph(conn, script_params, image, polylines, line_width,
@@ -366,7 +344,7 @@ def process_images(conn, script_params):
 
                 elif type(s) == omero.model.PolylineI:
                     v = s.getPoints().getValue()
-                    points = points_string_to_xy_list(v)
+                    points = roi_utils.points_string_to_xy_list(v)
                     polylines[t] = {'theZ': z, 'points': points}
 
             if len(lines) > 0:

--- a/omero/analysis_scripts/Kymograph.py
+++ b/omero/analysis_scripts/Kymograph.py
@@ -45,6 +45,28 @@ import logging
 logger = logging.getLogger('kymograph')
 
 
+def points_string_to_xy_list(string):
+    """
+    Method for converting the string returned from
+    omero.model.ShapeI.getPoints() into list of (x,y) points
+    e.g. "points[309,427, 366,503, 190,491]"
+    """
+    point_lists = string.strip().split("points")
+    if len(point_lists) < 2:
+        if len(point_lists) == 1 and point_lists[0]:
+            xys = point_lists[0].split()
+            xy_list = [tuple(map(float, xy.split(','))) for xy in xys]
+            return xy_list
+        raise ValueError("Unrecognised ROI shape 'points' string: %s" % string)
+
+    first_list = point_lists[1]
+    xy_list = []
+    for xy in first_list.strip(" []").split(", "):
+        x, y = xy.split(",")
+        xy_list.append((int(x.strip()), int(y.strip())))
+    return xy_list
+
+
 def polyline_kymograph(conn, script_params, image, polylines, line_width,
                        dataset):
     """
@@ -254,7 +276,7 @@ def process_images(conn, script_params):
 
                 elif type(s) == omero.model.PolylineI:
                     v = s.getPoints().getValue()
-                    points = roi_utils.points_string_to_xy_list(v)
+                    points = points_string_to_xy_list(v)
                     polylines[t] = {'theZ': z, 'points': points}
 
             if len(lines) > 0:

--- a/omero/analysis_scripts/Kymograph_Analysis.py
+++ b/omero/analysis_scripts/Kymograph_Analysis.py
@@ -34,32 +34,10 @@ from omero.rtypes import rlong, rstring, robject
 from omero.model import ImageAnnotationLinkI, ImageI
 import omero.scripts as scripts
 import omero.util.script_utils as script_utils
+import omero.util.roi_handling_utils as roi_utils
 import logging
 
 logger = logging.getLogger('kymograph_analysis')
-
-
-def points_string_to_xy_list(string):
-    """
-    Convert string to list of (x,y) points.
-
-    Expects string in format generated from omero.model.ShapeI.getPoints()
-    e.g. "points[309,427, 366,503]" to [(309,427), (366,503)]
-    """
-    point_lists = string.strip().split("points")
-    if len(point_lists) < 2:
-        if len(point_lists) == 1 and point_lists[0]:
-            xys = point_lists[0].split()
-            xy_list = [tuple(map(float, xy.split(','))) for xy in xys]
-            return xy_list
-        raise ValueError("Unrecognised ROI shape 'points' string: %s" % string)
-
-    first_list = point_lists[1]
-    xy_list = []
-    for xy in first_list.strip(" []").split(", "):
-        x, y = xy.split(",")
-        xy_list.append((float(x.strip()), float(y.strip())))
-    return xy_list
 
 
 def process_images(conn, script_params):
@@ -127,7 +105,7 @@ def process_images(conn, script_params):
                 elif type(s) == omero.model.PolylineI:
                     table_data += "\nPolyline ID: %s" % s.getId().getValue()
                     v = s.getPoints().getValue()
-                    points = points_string_to_xy_list(v)
+                    points = roi_utils.points_string_to_xy_list(v)
                     x_start, y_start = points[0]
                     for i in range(1, len(points)):
                         x1, y1 = points[i-1]

--- a/omero/analysis_scripts/Kymograph_Analysis.py
+++ b/omero/analysis_scripts/Kymograph_Analysis.py
@@ -34,10 +34,32 @@ from omero.rtypes import rlong, rstring, robject
 from omero.model import ImageAnnotationLinkI, ImageI
 import omero.scripts as scripts
 import omero.util.script_utils as script_utils
-import omero.util.roi_handling_utils as roi_utils
 import logging
 
 logger = logging.getLogger('kymograph_analysis')
+
+
+def points_string_to_xy_list(string):
+    """
+    Convert string to list of (x,y) points.
+
+    Expects string in format generated from omero.model.ShapeI.getPoints()
+    e.g. "points[309,427, 366,503]" to [(309,427), (366,503)]
+    """
+    point_lists = string.strip().split("points")
+    if len(point_lists) < 2:
+        if len(point_lists) == 1 and point_lists[0]:
+            xys = point_lists[0].split()
+            xy_list = [tuple(map(float, xy.split(','))) for xy in xys]
+            return xy_list
+        raise ValueError("Unrecognised ROI shape 'points' string: %s" % string)
+
+    first_list = point_lists[1]
+    xy_list = []
+    for xy in first_list.strip(" []").split(", "):
+        x, y = xy.split(",")
+        xy_list.append((float(x.strip()), float(y.strip())))
+    return xy_list
 
 
 def process_images(conn, script_params):
@@ -105,7 +127,7 @@ def process_images(conn, script_params):
                 elif type(s) == omero.model.PolylineI:
                     table_data += "\nPolyline ID: %s" % s.getId().getValue()
                     v = s.getPoints().getValue()
-                    points = roi_utils.points_string_to_xy_list(v)
+                    points = points_string_to_xy_list(v)
                     x_start, y_start = points[0]
                     for i in range(1, len(points)):
                         x1, y1 = points[i-1]

--- a/test/integration/test_analysis_scripts.py
+++ b/test/integration/test_analysis_scripts.py
@@ -67,7 +67,7 @@ class TestAnalysisScripts(ScriptTest):
         image_id = kymograph_img.getValue().id.val
         assert image_id > 0
         new_image = client.sf.getQueryService().get('Image', image_id)
-        assert new_image.name.val == "%skymograph" % image.name.val
+        assert new_image.name.val == "%s_kymograph" % image.name.val
 
     def test_plot_profile(self):
         script_id = super(TestAnalysisScripts, self).get_script(plot_profile)

--- a/test/integration/test_analysis_scripts.py
+++ b/test/integration/test_analysis_scripts.py
@@ -64,7 +64,11 @@ class TestAnalysisScripts(ScriptTest):
 
         # check the result
         assert kymograph_img is not None
-        assert kymograph_img.getValue().id.val > 0
+        image_id = kymograph_img.getValue().id.val
+        assert image_id > 0
+        new_image = client.sf.getQueryService().get('Image', image_id)
+        assert new_image.name.val == "%skymograph" % image.name.val
+
 
     def test_plot_profile(self):
         script_id = super(TestAnalysisScripts, self).get_script(plot_profile)

--- a/test/integration/test_analysis_scripts.py
+++ b/test/integration/test_analysis_scripts.py
@@ -69,7 +69,6 @@ class TestAnalysisScripts(ScriptTest):
         new_image = client.sf.getQueryService().get('Image', image_id)
         assert new_image.name.val == "%skymograph" % image.name.val
 
-
     def test_plot_profile(self):
         script_id = super(TestAnalysisScripts, self).get_script(plot_profile)
         assert script_id > 0

--- a/test/integration/test_analysis_scripts.py
+++ b/test/integration/test_analysis_scripts.py
@@ -50,7 +50,7 @@ class TestAnalysisScripts(ScriptTest):
         session = client.getSession()
         image = self.create_test_image(size_x, size_y, 1, 2, size_t, session)
         image_id = image.id.val
-        roi = create_roi(image_id, 0, size_x / 2, 0, size_y / 2, size_t, True)
+        roi = create_roi(image_id, -10, 80.5, 60, 11.1, size_t, True)
         session.getUpdateService().saveAndReturnObject(roi)
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image_id))
@@ -156,7 +156,7 @@ def create_roi(image_id, x1, x2, y1, y2, size_t, with_polylines):
             polyline = omero.model.PolylineI()
             polyline.theZ = omero.rtypes.rint(0)
             polyline.theT = omero.rtypes.rint(t)
-            points = [[10, 20], [50, 50], [75, 60]]
+            points = [[10.5, 20], [50.55, 50], [75, 60]]
             polyline.points = omero.rtypes.rstring(points_to_string(points))
             roi.addShape(polyline)
     return roi

--- a/test/integration/test_analysis_scripts.py
+++ b/test/integration/test_analysis_scripts.py
@@ -82,7 +82,7 @@ class TestAnalysisScripts(ScriptTest):
         session = client.getSession()
         image = self.create_test_image(size_x, size_y, 1, 2, size_t, session)
         image_id = image.id.val
-        roi = create_roi(image_id, 0, size_x / 2, 0, size_y / 2, size_t, True)
+        roi = create_roi(image_id, 0, size_x / 2, 0, size_y / 2, size_t, False)
         session.getUpdateService().saveAndReturnObject(roi)
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image_id))


### PR DESCRIPTION
This fixes the Kymograph script when Polylines are created with floating-point coordinates (as in iviewer).
Also fixes the joining of sections in the new images for Polyline kymographs.
To test, use image http://web-dev-merge.openmicroscopy.org/webclient/?show=image-138052 (user-3).

 - There are 2 ROIs drawn on the Image: 1 Line and 1 Polyline that matches the coordinates of the Line.
 - Running the Kymograph script on this Image should give 2 very similar Kymographs. This is how I noticed that the Polyline kymograph was previously stitching each section of the Polyline together in the wrong order, fixed by ```reverse()``` in aa6e232.

 The image above was created by importing a series of 8-bit pngs with a pattern file since the original image is uint16 and the numpy array from getTile(), when converted to PIL image is basically scrambled.