### PR TITLE
Combine Images setPlane

### DIFF
--- a/omero/util_scripts/Combine_Images.py
+++ b/omero/util_scripts/Combine_Images.py
@@ -367,8 +367,8 @@ def make_single_image(services, parameter_map, image_ids, dataset, colour_map):
                     pixel_sizes['y'].append(pixels.getPhysicalSizeY())
                 else:
                     plane_2d = zeros((size_y, size_x))
-                script_utils.upload_plane_by_row(
-                    raw_pixel_store_upload, plane_2d, the_z, the_c, the_t)
+                script_utils.upload_plane(raw_pixel_store_upload,
+                                          plane_2d, the_z, the_c, the_t)
                 min_value = min(min_value, plane_2d.min())
                 max_value = max(max_value, plane_2d.max())
         pixels_service.setChannelGlobalMinMax(pixels_id, the_c,


### PR DESCRIPTION
https://trello.com/c/xxnprbWz/35-combineimages-use-setplane

Simply use ```rawPixelStore.setPlane()``` instead of ```setRow()``` to improve speed of CombineImages.py script.

To test:
 - check that script still working as normal.
 - Travis should also be green (integration test passing)