### PR TITLE
Fix N816 warnings reported by Travis Ci

### DIFF
--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -87,25 +87,25 @@ MPEG = 'MPEG'
 QT = 'Quicktime'
 WMV = 'WMV'
 MOVIE_NS = NSMOVIE
-formatNSMap = {MPEG: MOVIE_NS, QT: MOVIE_NS, WMV: MOVIE_NS}
-formatExtensionMap = {MPEG: "avi", QT: "avi", WMV: "avi"}
-formatMap = {MPEG: "avi", QT: "avi", WMV: "avi"}
-formatMimetypes = {
+format_ns_map = {MPEG: MOVIE_NS, QT: MOVIE_NS, WMV: MOVIE_NS}
+format_extension_map = {MPEG: "avi", QT: "avi", WMV: "avi"}
+format_map = {MPEG: "avi", QT: "avi", WMV: "avi"}
+format_mimetypes = {
     MPEG: "video/mpeg",
     QT: "video/quicktime",
     WMV: "video/x-ms-wmv"}
 OVERLAYCOLOUR = "#666666"
 
 
-logLines = []    # make a log / legend of the figure
+log_lines = []    # make a log / legend of the figure
 
 
 def log(text):
     """
-    Adds lines of text to the logLines list, so they can be collected into a
+    Adds lines of text to the log_lines list, so they can be collected into a
     figure legend.
     """
-    logLines.append(text)
+    log_lines.append(text)
 
 
 def download_plane(gateway, pixels, pixels_id, x, y, z, c, t):
@@ -611,7 +611,7 @@ def write_movie(command_args, conn):
 
     filelist = ",".join(file_names)
 
-    ext = formatMap[format]
+    ext = format_map[format]
     movie_name = "Movie"
     if "Movie_Name" in command_args:
         movie_name = command_args["Movie_Name"]
@@ -626,7 +626,7 @@ def write_movie(command_args, conn):
         frames_per_sec = command_args["FPS"]
     output = "localfile.%s" % ext
     build_avi(mw, mh, filelist, frames_per_sec, output, format)
-    mimetype = formatMimetypes[format]
+    mimetype = format_mimetypes[format]
     omero_image._re.close()
 
     if not os.path.exists(output):
@@ -653,7 +653,7 @@ def run_script():
     def __init__(self, name, optional = False, out = False, description =
                  None, type = None, min = None, max = None, values = None)
     """
-    formats = wrap(formatMap.keys())    # wrap each key in its rtype
+    formats = wrap(format_map.keys())    # wrap each key in its rtype
     ckeys = COLOURS.keys()
     ckeys = ckeys
     ckeys.sort()

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -158,7 +158,7 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
     # if we have a list of tags, then sort images by tag
     if tag_ids:
         # Cast to int since List can be any type
-        tag_ids = [int(tagId) for tagId in tag_ids]
+        tag_ids = [int(tag_id) for tag_id in tag_ids]
         log(" Sorting images by tags: %s" % tag_ids)
         tag_names = {}
         tagged_images = {}    # a map of tagId: list-of-image-Ids

--- a/omero/util_scripts/Channel_Offsets.py
+++ b/omero/util_scripts/Channel_Offsets.py
@@ -226,8 +226,8 @@ def process_images(conn, script_params):
     # need to handle Datasets eventually - Just do images for now
     new_images = []
     links = []
-    for iId in image_ids:
-        new_img, link = new_image_with_channel_offsets(conn, iId,
+    for image_id in image_ids:
+        new_img, link = new_image_with_channel_offsets(conn, image_id,
                                                        channel_offsets,
                                                        dataset)
         if new_img is not None:

--- a/omero/util_scripts/Move_Annotations.py
+++ b/omero/util_scripts/Move_Annotations.py
@@ -47,7 +47,7 @@ def log(text):
 def move_well_annotations(conn, well, ann_type, remove_anns, ns):
     """Move annotations from Images in this Well onto the Well itself."""
     log("Processing Well: %s %s" % (well.id, well.getWellPos()))
-    iids = [wellSample.getImage().id for wellSample in well.listChildren()]
+    iids = [well_sample.getImage().id for well_sample in well.listChildren()]
     log("  Image IDs: %s" % iids)
     if len(iids) == 0:
         return 0


### PR DESCRIPTION
See also https://github.com/ome/omero-plugins/pull/2#issuecomment-471963106

This should fix https://travis-ci.org/ome/scripts  which weekly cron job has failing since the last month due to new warnings.

In addition to manual review, most of the testing (code style and integration) should happen in Travis CI.