### PR TITLE
Add 'Images_Per_Well' support to Dataset_To_Plate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,3 +47,19 @@ OMERO User Scripts
 
 If you would like to provide your own scripts for others to install
 into their OMERO installations, please see http://openmicroscopy.org/info/scripts
+
+
+Testing
+-------
+
+Integration tests under ``test/`` require an OMERO server with scripts installed.
+The tests are run by Travis for open PRs using omero-test-infra to deploy OMERO
+via Docker containers.
+
+To run tests locally:
+
+	# All tests
+	$ python setup.py test
+
+	# Single test in a single file
+	$ python setup.py test -t test/integration/test_util_scripts.py -k test_dataset_to_plate

--- a/test/integration/test_util_scripts.py
+++ b/test/integration/test_util_scripts.py
@@ -149,7 +149,7 @@ class TestUtilScripts(ScriptTest):
             self.link(dataset, image, client=client)
             image_ids.append(image.id.val)
 
-        # We run the script twice (parametrize). First with minimum args...
+        # Minimum args.
         dataset_ids = [omero.rtypes.rlong(dataset.id.val)]
         args = {
             "Data_Type": wrap("Dataset"),

--- a/test/integration/test_util_scripts.py
+++ b/test/integration/test_util_scripts.py
@@ -142,7 +142,6 @@ class TestUtilScripts(ScriptTest):
         # create several test images in a dataset
         dataset = self.make_dataset("dataset_to_plate-test", client=client)
         # Images will be sorted by name and assigned Column first
-        n = len(image_names)
         image_ids = []
         for i in image_names:
             # x,y,z,c,t
@@ -191,7 +190,6 @@ class TestUtilScripts(ScriptTest):
         # and all images were in the Plate
         images_in_plate.sort()
         assert images_in_plate == image_ids
-
 
     @pytest.mark.parametrize("remove", [True, False])
     @pytest.mark.parametrize("script_runner", ['user', 'admin'])


### PR DESCRIPTION
See recent queries about adding multiple Images per Well: https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8711&p=20693,
and https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8706

This PR updates the ```Dataset_To_Plate``` script to support multiple Images per Well.

To test:
 - The script should work "as normal" but the Well Per Image parameter can be used to add multiple Images per Well.
 - If there aren't enough images to fill the last Well, it will simply have fewer WellSamples than the other Wells.