### PR TITLE
batch export ROI coordinates

### DIFF
--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -193,7 +193,8 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
     if isinstance(shape, PolygonI):
         # https://www.mathopenref.com/coordpolygonarea.html
         coords = shape.getPoints().getValue().split(" ")
-        coords = [[float(x) for x in coord.split(",")] for coord in coords]
+        coords = [[float(x.strip(", ")) for x in coord.split(",")]
+                  for coord in coords]
         total = 0
         for c in range(len(coords)):
             coord = coords[c]

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -30,7 +30,7 @@ from omero.model import RectangleI, EllipseI, LineI, PolygonI, PolylineI, \
 from math import sqrt, pi
 import re
 
-DEFAULT_FILE_NAME = "roi_intensities.csv"
+DEFAULT_FILE_NAME = "Batch_ROI_Export.csv"
 INSIGHT_POINT_LIST_RE = re.compile(r'points\[([^\]]+)\]')
 
 

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -187,7 +187,7 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
         row_data['Points'] = '"%s"' % point_list
     if isinstance(shape, PolylineI):
         coords = point_list.split(" ")
-        coords = [[float(x.strip(", ")) for x in coord.split(",")]
+        coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
                   for coord in coords]
         lengths = []
         for i in range(len(coords)-1):
@@ -200,7 +200,7 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
     if isinstance(shape, PolygonI):
         # https://www.mathopenref.com/coordpolygonarea.html
         coords = point_list.split(" ")
-        coords = [[float(x.strip(", ")) for x in coord.split(",")]
+        coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
                   for coord in coords]
         total = 0
         for c in range(len(coords)):

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -72,9 +72,12 @@ def get_export_data(conn, script_params, image, units=None):
 
     result = roi_service.findByImage(image.getId(), None)
 
+    rois = result.rois
+    # Sort by ROI.id (same as in iviewer)
+    rois.sort(key = lambda r: r.id.val)
     export_data = []
 
-    for roi in result.rois:
+    for roi in rois:
         for shape in roi.copyShapes():
             label = unwrap(shape.getTextValue())
             # wrap label in double quotes in case it contains comma

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -74,7 +74,7 @@ def get_export_data(conn, script_params, image, units=None):
 
     rois = result.rois
     # Sort by ROI.id (same as in iviewer)
-    rois.sort(key = lambda r: r.id.val)
+    rois.sort(key=lambda r: r.id.val)
     export_data = []
 
     for roi in rois:

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -31,6 +31,7 @@ from math import sqrt, pi
 import re
 
 DEFAULT_FILE_NAME = "roi_intensities.csv"
+INSIGHT_POINT_LIST_RE = re.compile(r'points\[([^\]]+)\]')
 
 
 def log(data):
@@ -180,7 +181,6 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
         row_data['length'] = sqrt((dx * dx) + (dy * dy))
     if isinstance(shape, (PolygonI, PolylineI)):
         point_list = shape.getPoints().getValue()
-        INSIGHT_POINT_LIST_RE = re.compile(r'points\[([^\]]+)\]')
         match = INSIGHT_POINT_LIST_RE.search(point_list)
         if match is not None:
             point_list = match.group(1)

--- a/test/integration/test_export_scripts.py
+++ b/test/integration/test_export_scripts.py
@@ -122,14 +122,17 @@ class TestExportScripts(ScriptTest):
         # Check first 2 rows of csv (except Std dev)
         zt = ","
         points_min_max_sum_mean = ",,,,"
+        area = "6561.0"
         if all_planes:
             zt = "1,1"
             points_min_max_sum_mean = "6561,10.0,90.0,328050.0,50.0"
         expected = ("image_id,image_name,roi_id,shape_id,type,text,"
-                    "z,t,channel,points,min,max,sum,mean,std_dev\n"
-                    "%s,\"%s\",%s,%s,polygon,\"%s\",%s,0,%s,") % (
+                    "z,t,channel,area (pixels),length (pixels),"
+                    "points,min,max,sum,mean,std_dev,"
+                    "X,Y,Width,Height,RadiusX,RadiusY,X1,Y1,X2,Y2,Points\n"
+                    "%s,\"%s\",%s,%s,polygon,\"%s\",%s,0,%s,,%s,") % (
             image.id.val, image_name, roi.id.val,
-            polygon.id.val, label_text, zt, points_min_max_sum_mean)
+            polygon.id.val, label_text, zt, area, points_min_max_sum_mean)
         assert csv_text.startswith(expected)
 
     @pytest.mark.broken(


### PR DESCRIPTION
Noticed during the Dundee workshop - the Batch_ROI_Export script didn't include shape coordinates, lengths or areas. This adds them to the exported CSV, similar to export from iviewer: https://github.com/ome/omero-iviewer/pull/257

To test:
 - Draw all types of Shape on one or more images.
 - Compare export of ROIs csv from iviewer and the output of the Batch_ROI_Export script.
 - Test on images with various pixel sizes or None. If *any* images have NO pixel size set, we use 'pixels' for length and area for all images (since we can't convert).

NB: We use the same pixel size units for the length and area of shapes from all images (since the column has a single unit in header). If some images have very different pixel size units from other images, we could get some very big or small numbers in the CSV, but we can probably assume they are similar if being exported together.

NB: The length and area are converted to length units (e.g. microns) but the shape coordinates are not. They are given in pixel coordinates, including e.g. the Rectangle Width and Height. This is the same behaviour as for iviewer ROI export. I think it makes sense and hope this will be understood by users.