### PR TITLE
Populate metadata Datasets and Projects

### DIFF
--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -34,7 +34,7 @@ from omero.util.populate_roi import DownloadingOriginalFileProvider
 try:
     # Hopefully this will import
     # https://github.com/ome/omero-metadata/blob/v0.3.1/src/populate_metadata.py
-    from populate_metadata import ParsingContext
+    from omero_metadata.populate import ParsingContext
     OBJECT_TYPES = (
         'Plate',
         'Screen',

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -129,9 +129,10 @@ def run_script():
             "IDs", optional=False, grouping="2",
             description="Container ID.").ofType(rlong(0)),
 
-        scripts.String(
+        scripts.Long(
             "File_Annotation", grouping="3",
-            description="File ID containing metadata to populate."),
+            description="File Annotation ID containing metadata to populate. "
+            "Note this is not the same as the File ID."),
 
         authors=["Emil Rozbicki", "OME Team"],
         institutions=["Glencoe Software Inc."],

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -129,7 +129,7 @@ def run_script():
             "IDs", optional=False, grouping="2",
             description="Container ID.").ofType(rlong(0)),
 
-        scripts.Long(
+        scripts.String(
             "File_Annotation", grouping="3",
             description="File Annotation ID containing metadata to populate. "
             "Note this is not the same as the File ID."),

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -93,8 +93,8 @@ def populate_metadata(client, conn, script_params):
     provider = DownloadingOriginalFileProvider(conn)
     data_for_preprocessing = provider.get_original_file_data(original_file)
     data = provider.get_original_file_data(original_file)
-    objectI = getattr(omero.model, data_type + 'I')
-    omero_object = objectI(long(object_id), False)
+    objecti = getattr(omero.model, data_type + 'I')
+    omero_object = objecti(long(object_id), False)
     ctx = ParsingContext(client, omero_object, "")
 
     try:

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -67,7 +67,7 @@ class TestImportScripts(ScriptTest):
         args = {
             "Data_Type": omero.rtypes.rstring("Plate"),
             "IDs": omero.rtypes.rlist(plate_ids),
-            "File_Annotation": omero.rtypes.rstring(str(fa.id))
+            "File_Annotation": omero.rtypes.rlong(str(fa.id))
         }
         message = run_script(client, sid, args, "Message")
         assert message is not None
@@ -118,7 +118,7 @@ class TestImportScripts(ScriptTest):
         args = {
             "Data_Type": omero.rtypes.rstring("Screen"),
             "IDs": omero.rtypes.rlist(screen_ids),
-            "File_Annotation": omero.rtypes.rstring(str(fa.id))
+            "File_Annotation": omero.rtypes.rlong(str(fa.id))
         }
         message = run_script(client, sid, args, "Message")
         assert message is not None

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -67,7 +67,7 @@ class TestImportScripts(ScriptTest):
         args = {
             "Data_Type": omero.rtypes.rstring("Plate"),
             "IDs": omero.rtypes.rlist(plate_ids),
-            "File_Annotation": omero.rtypes.rlong(str(fa.id))
+            "File_Annotation": omero.rtypes.rstring(str(fa.id))
         }
         message = run_script(client, sid, args, "Message")
         assert message is not None
@@ -118,7 +118,7 @@ class TestImportScripts(ScriptTest):
         args = {
             "Data_Type": omero.rtypes.rstring("Screen"),
             "IDs": omero.rtypes.rlist(screen_ids),
-            "File_Annotation": omero.rtypes.rlong(str(fa.id))
+            "File_Annotation": omero.rtypes.rstring(str(fa.id))
         }
         message = run_script(client, sid, args, "Message")
         assert message is not None


### PR DESCRIPTION
Requires the omero-metadata plugin. Otherwise reverts to the old behaviour and includes a deprecation warning in the script description.

Updated 20190703: New functionality requires https://github.com/ome/omero-metadata/pull/19