### PR TITLE
populate metadata links file ann

### DIFF
--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -57,7 +57,22 @@ except ImportError:
     """
 
 
-def get_original_file(conn, object_type, object_id, file_ann_id=None):
+def link_file_ann(conn, object_type, object_id, file_ann_id):
+    """Link File Annotation to the Object, if not already linked."""
+    file_ann = conn.getObject("Annotation", file_ann_id)
+    if file_ann is None:
+        sys.stderr.write("Error: File Annotation not found: %s.\n"
+                         % file_ann_id)
+        sys.exit(1)
+    omero_object = get_object(conn, object_type, object_id)
+    # Check for existing links
+    links = list(conn.getAnnotationLinks(object_type, parent_ids=[object_id],
+                                         ann_ids=[file_ann_id]))
+    if len(links) == 0:
+        omero_object.linkAnnotation(file_ann)
+
+
+def get_object(conn, object_type, object_id):
     if object_type not in OBJECT_TYPES:
         sys.stderr.write("Error: Invalid object type: %s.\n" % object_type)
         sys.exit(1)
@@ -65,6 +80,11 @@ def get_original_file(conn, object_type, object_id, file_ann_id=None):
     if omero_object is None:
         sys.stderr.write("Error: %s does not exist.\n" % object_type)
         sys.exit(1)
+    return omero_object
+
+
+def get_original_file(conn, object_type, object_id, file_ann_id=None):
+    omero_object = get_object(conn, object_type, object_id)
     file_ann = None
 
     for ann in omero_object.listAnnotations():
@@ -84,10 +104,11 @@ def get_original_file(conn, object_type, object_id, file_ann_id=None):
 def populate_metadata(client, conn, script_params):
     object_ids = script_params["IDs"]
     object_id = object_ids[0]
+    data_type = script_params["Data_Type"]
     file_ann_id = None
     if "File_Annotation" in script_params:
         file_ann_id = long(script_params["File_Annotation"])
-    data_type = script_params["Data_Type"]
+        link_file_ann(conn, data_type, object_id, file_ann_id)
     original_file = get_original_file(
         conn, data_type, object_id, file_ann_id)
     provider = DownloadingOriginalFileProvider(conn)


### PR DESCRIPTION
This change is needed to allow populate_metadata script to work with the File-picker from https://github.com/ome/openmicroscopy/pull/6096
That PR passes the uploaded FileAnnotation ID to populate-metadata script, but the script expects the FileAnnotation to be linked to the selected object.
This PR links the FileAnnotation to the object, which also has the benefit of not 'losing' the new FileAnnotation with it being unlinked.

To test:
 - Create or find a CSV FileAnnotation for populate metadata. E.g. https://merge-ci.openmicroscopy.org/web/webclient/?show=dataset-4919 (user-3)
 - Note the FileAnnotation ID - (9987) then *unlink* (don't delete) the Annotation from the Dataset.
 - Run populate_metadata script on the Dataset, entering the File Annotation ID.
 - Check that the populate-metadata works as expected to create an OMERO.table and that the csv becomes linked to the Dataset.
 - If the File_Annotation ID is filled out in the script (and the FileAnnotation is already linked to the object) then script should continue to work as before