### PR TITLE
Set proper version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ class PyTest(test_command):
         sys.exit(errno)
 
 
-version = '0.1.0'
+version = '5.5.1'
 url = "https://github.com/ome/scripts/"
 
 setup(


### PR DESCRIPTION
As with https://github.com/ome/omero-py/pull/15, in order to use:

```
python setup.py --version
```

as the basis for build-infra's `foreach-get-version` the setup.py version will need to be kept in sync with `git describe`.