### PR TITLE
Migrate testParseAllOfficialScripts here

### DIFF
--- a/test/unit/test_parse.py
+++ b/test/unit/test_parse.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+   Test of the omero.scripts.parse functionality
+   Copyright 2009-2019 Open Microscopy Environment. All rights reserved.
+   Use is subject to license terms supplied in LICENSE.txt
+"""
+
+
+from path import path
+from omero.scripts import parse_file
+
+
+SCRIPTS = path(".") / ".." / "omero"
+
+
+class TestParse(object):
+
+    def test_parse_all_official_scripts(self):
+        for script in SCRIPTS.walk("*.py"):
+            try:
+                parse_file(str(script))
+            except Exception, e:
+                assert False, "%s\n%s" % (script, e)


### PR DESCRIPTION
see:
 - https://github.com/ome/omero-py/pull/10#pullrequestreview-281971929

running `.omero/docker scripts:`:

```
...
test/integration/test_util_scripts.py::TestUtilScripts::test_move_annotations[user-False] PASSED [ 90%]
test/integration/test_util_scripts.py::TestUtilScripts::test_move_annotations[admin-True] PASSED [ 93%]
test/integration/test_util_scripts.py::TestUtilScripts::test_move_annotations[admin-False] PASSED [ 96%]
test/unit/test_parse.py::TestParse::test_parse_all_official_scripts PASSED [100%]

==================== 31 passed, 1 xfailed in 216.37 seconds ====================
Stopping scripts_db_1    ... done
Stopping scripts_web_1   ... done
Stopping scripts_omero_1 ... done
Removing scripts_db_1    ... done
Removing scripts_web_1   ... done
Removing scripts_omero_1 ... done
Removing network scripts_default```