### PR TITLE
Fix webclient_figure scripts

### DIFF
--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -228,14 +228,18 @@ def write_csv(conn, export_data, script_params, units_symbol):
         units_symbol = "pixels"
     csv_header = csv_header.replace(",length,", ",length (%s)," % units_symbol)
     csv_header = csv_header.replace(",area,", ",area (%s)," % units_symbol)
-    csv_rows = [csv_header]
+    csv_rows = [csv_header.encode('utf-8')]
 
     for row in export_data:
-        cells = [str(row.get(name, "")) for name in COLUMN_NAMES]
-        csv_rows.append(",".join(cells))
+        # cells = [("%s" % row.get(name, "")) for name in COLUMN_NAMES]
+        cells = []
+        for name in COLUMN_NAMES:
+            td = row.get(name, '')
+            cells.append(str(td).encode('utf-8'))
+        csv_rows.append(b",".join(cells))
 
-    with open(file_name, 'w') as csv_file:
-        csv_file.write("\n".join(csv_rows))
+    with open(file_name, 'wb') as csv_file:
+        csv_file.write(b"\n".join(csv_rows))
 
     return conn.createFileAnnfromLocalFile(file_name, mimetype="text/csv")
 

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -530,7 +530,7 @@ def write_movie(command_args, conn):
             command_args["Show_Time"] = False
 
     frame_no = 1
-    omero_image.setActiveChannels(map(lambda x: x+1, c_range),
+    omero_image.setActiveChannels([x+1 for x in c_range],
                                   c_windows, c_colours)
 
     overlay_colour = (255, 255, 255)

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -71,7 +71,7 @@ from omero.gateway import BlitzGateway
 from omero.constants.namespaces import NSCREATED
 from omero.constants.metadata import NSMOVIE
 
-from cStringIO import StringIO
+from io import BytesIO
 from types import StringTypes
 
 try:
@@ -403,8 +403,8 @@ def write_intro_end_slides(conn, command_args, orig_file_id, duration, size_x,
 
     # get Original File as Image
     slide_file = conn.getObject("OriginalFile", orig_file_id)
-    slide_data = "".join(slide_file.getFileInChunks())
-    i = StringIO(slide_data)
+    slide_data = b"".join(slide_file.getFileInChunks())
+    i = BytesIO(slide_data)
     slide = Image.open(i)
     slide = reshape_to_fit(slide, size_x, size_y)
 
@@ -433,8 +433,8 @@ def prepare_watermark(conn, command_args, size_x, size_y):
     wm_orig_file = command_args["Watermark"]
     # get Original File as Image
     wm_file = conn.getObject("OriginalFile", wm_orig_file.getId().getValue())
-    wm_data = "".join(wm_file.getFileInChunks())
-    i = StringIO(wm_data)
+    wm_data = b"".join(wm_file.getFileInChunks())
+    i = BytesIO(wm_data)
     wm = Image.open(i)
     wm_w, wm_h = wm.size
     # only resize watermark if too big

--- a/omero/export_scripts/Make_Movie.py
+++ b/omero/export_scripts/Make_Movie.py
@@ -654,8 +654,7 @@ def run_script():
                  None, type = None, min = None, max = None, values = None)
     """
     formats = wrap(format_map.keys())    # wrap each key in its rtype
-    ckeys = COLOURS.keys()
-    ckeys = ckeys
+    ckeys = list(COLOURS.keys())
     ckeys.sort()
     c_options = wrap(ckeys)
     data_types = [rstring("Image")]

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -553,7 +553,7 @@ def run_script():
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
     ckeys = list(COLOURS.keys())
     ckeys.sort()
-    o_colours = wrap(OVERLAY_COLOURS.keys())
+    o_colours = wrap(list(OVERLAY_COLOURS.keys()))
 
     client = scripts.client(
         'Movie_Figure.py',

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -302,7 +302,7 @@ def add_left_labels(panel_canvas, image_labels, row_index, width, spacer):
     max_count = 0
     for row in image_labels:
         max_count = max(max_count, len(row))
-    left_text_height = (text_height + text_gap) * max_count
+    left_text_height = int((text_height + text_gap) * max_count)
     # make the canvas as wide as the panels height
     left_text_width = panel_canvas.size[1]
     size = (left_text_width, left_text_height)

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -191,11 +191,11 @@ def createmovie_figure(conn, pixel_ids, t_indexes, z_start, z_end, width,
         # make a canvas for the row of splitview images...
         # (will add time labels above each row)
         col_count = min(max_col_count, len(rendered_images))
-        row_count = int(math.ceil(float(len(rendered_images)) / col_count))
-        font = image_utils.get_font(width/12)
+        row_count = int(math.ceil(len(rendered_images) / col_count))
+        font = image_utils.get_font(width // 12)
         font_height = font.getsize("Textq")[1]
         canvas_width = ((width + spacer) * col_count) + spacer
-        canvas_height = row_count * (spacer/2 + font_height + spacer + height)
+        canvas_height = row_count * (spacer // 2 + font_height + spacer + height)
         size = (canvas_width, canvas_height)
         # create a canvas of appropriate width, height
         canvas = Image.new(mode, size, white)
@@ -203,7 +203,7 @@ def createmovie_figure(conn, pixel_ids, t_indexes, z_start, z_end, width,
         # add text labels
         query_service = conn.getQueryService()
         text_x = spacer
-        text_y = spacer/4
+        text_y = spacer // 4
         col_index = 0
         time_labels = figUtil.getTimeLabels(
             query_service, pixels_id, t_indexes, size_t, time_units)
@@ -212,7 +212,7 @@ def createmovie_figure(conn, pixel_ids, t_indexes, z_start, z_end, width,
                 continue
             time = time_labels[t]
             text_w = font.getsize(time)[0]
-            inset = (width - text_w) / 2
+            inset = (width - text_w) // 2
             textdraw = ImageDraw.Draw(canvas)
             textdraw.text((text_x+inset, text_y), time, font=font,
                           fill=(0, 0, 0))
@@ -221,7 +221,7 @@ def createmovie_figure(conn, pixel_ids, t_indexes, z_start, z_end, width,
             if col_index >= max_col_count:
                 col_index = 0
                 text_x = spacer
-                text_y += (spacer/2 + font_height + spacer + height)
+                text_y += (spacer // 2 + font_height + spacer + height)
 
         # add scale bar to last frame...
         if scalebar:
@@ -248,7 +248,7 @@ def createmovie_figure(conn, pixel_ids, t_indexes, z_start, z_end, width,
             if col_index >= max_col_count:
                 col_index = 0
                 px = spacer
-                py += (spacer/2 + font_height + spacer + height)
+                py += (spacer // 2 + font_height + spacer + height)
 
         # Add labels to the left of the panel
         canvas = add_left_labels(canvas, image_labels, row, width, spacer)
@@ -266,7 +266,7 @@ def createmovie_figure(conn, pixel_ids, t_indexes, z_start, z_end, width,
     figure_size = (total_width, total_height+spacer)
     figure_canvas = Image.new(mode, figure_size, white)
 
-    row_y = spacer / 2
+    row_y = spacer // 2
     for row in row_panels:
         image_utils.paste_image(row, figure_canvas, 0, row_y)
         row_y = row_y + row.size[1]
@@ -335,7 +335,7 @@ def add_left_labels(panel_canvas, image_labels, row_index, width, spacer):
     # want it to be vertical. Rotate and paste the text canvas from above
     if image_labels:
         text_v = text_canvas.rotate(90, expand=True)
-        image_utils.paste_image(text_v, canvas, spacer/2, 0)
+        image_utils.paste_image(text_v, canvas, spacer // 2, 0)
 
     return canvas
 
@@ -461,7 +461,7 @@ def movie_figure(conn, command_args):
     if "Height" in command_args:
         height = command_args["Height"]
 
-    spacer = (width/25) + 2
+    spacer = (width // 25) + 2
 
     algorithm = ProjectionType.MAXIMUMINTENSITY
     if "Algorithm" in command_args:

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -195,7 +195,8 @@ def createmovie_figure(conn, pixel_ids, t_indexes, z_start, z_end, width,
         font = image_utils.get_font(width // 12)
         font_height = font.getsize("Textq")[1]
         canvas_width = ((width + spacer) * col_count) + spacer
-        canvas_height = row_count * (spacer // 2 + font_height + spacer + height)
+        canvas_height = row_count * (spacer // 2 + font_height +
+                                     spacer + height)
         size = (canvas_width, canvas_height)
         # create a canvas of appropriate width, height
         canvas = Image.new(mode, size, white)

--- a/omero/figure_scripts/Movie_Figure.py
+++ b/omero/figure_scripts/Movie_Figure.py
@@ -551,7 +551,7 @@ def run_script():
     tunits = [rstring("SECS"), rstring("MINS"), rstring("HOURS"),
               rstring("MINS SECS"), rstring("HOURS MINS")]
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
-    ckeys = COLOURS.keys()
+    ckeys = list(COLOURS.keys())
     ckeys.sort()
     o_colours = wrap(OVERLAY_COLOURS.keys())
 

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -726,7 +726,7 @@ any ROI."""
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
     ckeys = list(COLOURS.keys())
     ckeys.sort()
-    o_colours = wrap(OVERLAY_COLOURS.keys())
+    o_colours = wrap(list(OVERLAY_COLOURS.keys()))
 
     client = scripts.client(
         'Movie_ROI_Figure.py',

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -724,7 +724,7 @@ def run_script():
 'FigureROI' by default, (not case sensitive). If matching ROI not found, use \
 any ROI."""
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
-    ckeys = COLOURS.keys()
+    ckeys = list(COLOURS.keys())
     ckeys.sort()
     o_colours = wrap(OVERLAY_COLOURS.keys())
 

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -76,7 +76,7 @@ def get_time_indexes(time_points, max_frames):
     """
     frames = min(max_frames, time_points)
     interval_count = frames-1
-    smallest_interval = (time_points-1)/interval_count
+    smallest_interval = (time_points-1)//interval_count
     # make a list of intervals, making the last intervals bigger if needed
     intervals = [smallest_interval] * interval_count
     extra = (time_points-1) % interval_count
@@ -198,7 +198,7 @@ def get_roi_movie_view(re, query_service, pixels, time_shape_map,
     col_count = len(rendered_images)
     row_count = 1
     if max_columns:
-        row_count = col_count / max_columns
+        row_count = col_count // max_columns
         if (col_count % max_columns) > 0:
             row_count += 1
         col_count = max_columns
@@ -213,7 +213,7 @@ def get_roi_movie_view(re, query_service, pixels, time_shape_map,
     canvas = Image.new(mode, size, white)
 
     px = 0
-    text_y = spacer/2
+    text_y = spacer // 2
     panel_y = text_height + spacer
     # paste the images in, with time labels
     draw = ImageDraw.Draw(canvas)
@@ -221,7 +221,7 @@ def get_roi_movie_view(re, query_service, pixels, time_shape_map,
     col = 0
     for i, img in enumerate(rendered_images):
         label = time_labels[i]
-        indent = (panel_width - (font.getsize(label)[0])) / 2
+        indent = (panel_width - (font.getsize(label)[0])) // 2
         draw.text((px+indent, text_y), label, font=font, fill=(0, 0, 0))
         image_utils.paste_image(img, canvas, px, panel_y)
         if col == (col_count - 1):
@@ -358,7 +358,7 @@ def get_split_view(conn, image_ids, pixel_ids, merged_indexes, merged_colours,
         return
     x, y, roi_width, roi_height, time_shape_map = rect
 
-    roi_outline = ((max(width, height)) / 200) + 1
+    roi_outline = ((max(width, height)) // 200) + 1
 
     if roi_zoom is None:
         # get the pixels for priamry image.
@@ -370,7 +370,7 @@ def get_split_view(conn, image_ids, pixel_ids, merged_indexes, merged_colours,
     else:
         log("ROI zoom: %F X" % roi_zoom)
 
-    text_gap = spacer/3
+    text_gap = spacer // 3
     font_size = 12
     if width > 500:
         font_size = 48
@@ -439,10 +439,10 @@ def get_split_view(conn, image_ids, pixel_ids, merged_indexes, merged_colours,
 
         # draw ROI onto mergedImage...
         # recalculate roi if the image has been zoomed
-        x = roi_x / image_zoom
-        y = roi_y / image_zoom
-        roi_x2 = (roi_x + roi_width) / image_zoom
-        roi_y2 = (roi_y + roi_height) / image_zoom
+        x = roi_x // image_zoom
+        y = roi_y // image_zoom
+        roi_x2 = (roi_x + roi_width) // image_zoom
+        roi_y2 = (roi_y + roi_height) // image_zoom
         draw_rectangle(
             merged_image, x, y, roi_x2, roi_y2, overlay_colour, roi_outline)
 
@@ -467,8 +467,8 @@ def get_split_view(conn, image_ids, pixel_ids, merged_indexes, merged_colours,
     for row, image in enumerate(merged_images):
         label_canvas = figUtil.getVerticalLabels(image_labels[row], font,
                                                  text_gap)
-        v_offset = (image.size[1] - label_canvas.size[1]) / 2
-        image_utils.paste_image(label_canvas, figure_canvas, spacer / 2,
+        v_offset = (image.size[1] - label_canvas.size[1]) // 2
+        image_utils.paste_image(label_canvas, figure_canvas, spacer // 2,
                                 row_y+top_spacers[row] + v_offset)
         image_utils.paste_image(
             image, figure_canvas, left_text_width, row_y + top_spacers[row])
@@ -660,7 +660,7 @@ def roi_figure(conn, command_args):
     if "Roi_Selection_Label" in command_args:
         roi_label = command_args["Roi_Selection_Label"]
 
-    spacer = (width/50) + 2
+    spacer = (width // 50) + 2
 
     fig = get_split_view(
         conn, image_ids, pixel_ids, merged_indexes, merged_colours, width,

--- a/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/omero/figure_scripts/Movie_ROI_Figure.py
@@ -600,7 +600,7 @@ def roi_figure(conn, command_args):
         # convert to 0-based
         merged_indexes = [c-1 for c in command_args["Merged_Channels"]]
     else:
-        merged_indexes = range(size_c)  # show all
+        merged_indexes = list(range(size_c))  # show all
     merged_indexes.reverse()
 
     #  if no colours added, use existing rendering settings.

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -821,7 +821,7 @@ def run_script():
 'FigureROI' by default, (not case sensitive). If matching ROI not found, use \
 any ROI."""
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
-    ckeys = COLOURS.keys()
+    ckeys = list(COLOURS.keys())
     ckeys.sort()
     o_colours = wrap(OVERLAY_COLOURS.keys())
 

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -682,7 +682,7 @@ def roi_figure(conn, command_args):
         merged_indexes.sort()
     # make sure we have some merged channels
     if len(merged_indexes) == 0:
-        merged_indexes = range(size_c)
+        merged_indexes = list(range(size_c))
     merged_indexes.reverse()
 
     merged_names = False

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -538,8 +538,8 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
         label_canvas = figUtil.getVerticalLabels(image_labels[row], font,
                                                  text_gap)
         v_offset = (image.size[1] - label_canvas.size[1]) // 2
-        image_utils.paste_image(label_canvas, figure_canvas, spacer // 2,
-                                row_y + top_spacers[row] + v_offset)
+        image_utils.paste_image(label_canvas, figure_canvas, int(spacer // 2),
+                                int(row_y + top_spacers[row] + v_offset))
         image_utils.paste_image(
             image, figure_canvas, left_text_width, row_y + top_spacers[row])
         x = left_text_width + width + spacer

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -540,8 +540,8 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
         v_offset = (image.size[1] - label_canvas.size[1]) // 2
         image_utils.paste_image(label_canvas, figure_canvas, int(spacer // 2),
                                 int(row_y + top_spacers[row] + v_offset))
-        image_utils.paste_image(
-            image, figure_canvas, left_text_width, row_y + top_spacers[row])
+        image_utils.paste_image(image, figure_canvas, int(left_text_width),
+                                int(row_y + top_spacers[row]))
         x = left_text_width + width + spacer
         image_utils.paste_image(roi_split_panes[row], figure_canvas, x, row_y)
         row_y = row_y + max(image.size[1] + top_spacers[row],

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -52,12 +52,6 @@ except ImportError:
     import Image
     import ImageDraw  # see ticket:2597
 
-try:
-    long
-except Exception:
-    # Python 3
-    long = int
-
 
 COLOURS = script_utils.COLOURS    # name:(rgba) map
 OVERLAY_COLOURS = dict(COLOURS, **script_utils.EXTRA_COLOURS)
@@ -169,8 +163,8 @@ def get_roi_split_view(re, pixels, z_start, z_end, split_indexes,
                 # if it's a single plane, we can render a region (region not
                 # supported with projection)
                 plane_def = omero.romio.PlaneDef()
-                plane_def.z = long(pro_start)
-                plane_def.t = long(t_index)
+                plane_def.z = int(pro_start)
+                plane_def.t = int(t_index)
                 region_def = omero.romio.RegionDef()
                 region_def.x = roi_x
                 region_def.y = roi_y

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -235,8 +235,8 @@ def get_roi_split_view(re, pixels, z_start, z_end, split_indexes,
             top_spacer = text_height + spacer
     image_count = len(rendered_images) + 1     # extra image for merged image
     # no spaces around panels
-    canvas_width = ((panel_width + spacer) * image_count) - spacer
-    canvas_height = roi_merged_image.size[1] + top_spacer
+    canvas_width = int(((panel_width + spacer) * image_count) - spacer)
+    canvas_height = int(roi_merged_image.size[1] + top_spacer)
 
     size = (canvas_width, canvas_height)
     # create a canvas of appropriate width, height
@@ -248,7 +248,7 @@ def get_roi_split_view(re, pixels, z_start, z_end, split_indexes,
     # paste the split images in, with channel labels
     draw = ImageDraw.Draw(canvas)
     for i, index in enumerate(split_indexes):
-        label = channel_names[index]
+        label = channel_names.get(index, index)
         indent = (panel_width - (font.getsize(label)[0])) // 2
         # text is coloured if channel is not coloured AND in the merged image
         rgb = (0, 0, 0)

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -823,7 +823,7 @@ any ROI."""
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
     ckeys = list(COLOURS.keys())
     ckeys.sort()
-    o_colours = wrap(OVERLAY_COLOURS.keys())
+    o_colours = wrap(list(OVERLAY_COLOURS.keys()))
 
     client = scripts.client(
         'ROI_Split_Figure.py',

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -530,7 +530,7 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
     # each row has 1/2 spacer above and below the panels. Need extra 1/2
     # spacer top and bottom
     canvas_width = left_text_width + width + 2 * spacer + max_split_panel_width
-    figure_size = (canvas_width, total_canvas_height + spacer)
+    figure_size = (int(canvas_width), int(total_canvas_height + spacer))
     figure_canvas = Image.new("RGB", figure_size, (255, 255, 255))
 
     row_y = spacer

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -243,13 +243,13 @@ def get_roi_split_view(re, pixels, z_start, z_end, split_indexes,
     canvas = Image.new(mode, size, white)
 
     px = 0
-    text_y = top_spacer - text_height - spacer/2
+    text_y = top_spacer - text_height - spacer // 2
     panel_y = top_spacer
     # paste the split images in, with channel labels
     draw = ImageDraw.Draw(canvas)
     for i, index in enumerate(split_indexes):
         label = channel_names[index]
-        indent = (panel_width - (font.getsize(label)[0])) / 2
+        indent = (panel_width - (font.getsize(label)[0])) // 2
         # text is coloured if channel is not coloured AND in the merged image
         rgb = (0, 0, 0)
         if index in merged_colours:
@@ -408,7 +408,7 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
         raise Exception("No ROI found for the first image.")
     roi_x, roi_y, roi_width, roi_height, y_min, y_max, t_min, t_max = rect
 
-    roi_outline = ((max(width, height)) / 200) + 1
+    roi_outline = ((max(width, height)) // 200) + 1
 
     if roi_zoom is None:
         # get the pixels for priamry image.
@@ -420,7 +420,7 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
     else:
         log("ROI zoom: %F X" % roi_zoom)
 
-    text_gap = spacer/3
+    text_gap = spacer // 3
     fontsize = 12
     if width > 500:
         fontsize = 48
@@ -504,10 +504,10 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
 
         # draw ROI onto mergedImage...
         # recalculate roi if the image has been zoomed
-        x = roi_x / image_zoom
-        y = roi_y / image_zoom
-        roi_x2 = (roi_x + roi_width) / image_zoom
-        roi_y2 = (roi_y + roi_height) / image_zoom
+        x = roi_x // image_zoom
+        y = roi_y // image_zoom
+        roi_x2 = (roi_x + roi_width) // image_zoom
+        roi_y2 = (roi_y + roi_height) // image_zoom
         draw_rectangle(
             merged_image, x, y, roi_x2, roi_y2, overlay_colour, roi_outline)
 
@@ -537,8 +537,8 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
     for row, image in enumerate(merged_images):
         label_canvas = figUtil.getVerticalLabels(image_labels[row], font,
                                                  text_gap)
-        v_offset = (image.size[1] - label_canvas.size[1]) / 2
-        image_utils.paste_image(label_canvas, figure_canvas, spacer/2,
+        v_offset = (image.size[1] - label_canvas.size[1]) // 2
+        image_utils.paste_image(label_canvas, figure_canvas, spacer // 2,
                                 row_y + top_spacers[row] + v_offset)
         image_utils.paste_image(
             image, figure_canvas, left_text_width, row_y + top_spacers[row])

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -244,7 +244,7 @@ def get_roi_split_view(re, pixels, z_start, z_end, split_indexes,
 
     px = 0
     text_y = top_spacer - text_height - spacer // 2
-    panel_y = top_spacer
+    panel_y = int(top_spacer)
     # paste the split images in, with channel labels
     draw = ImageDraw.Draw(canvas)
     for i, index in enumerate(split_indexes):
@@ -262,7 +262,7 @@ def get_roi_split_view(re, pixels, z_start, z_end, split_indexes,
             draw.text((px+indent, text_y), label, font=font, fill=rgb)
         if i < len(rendered_images):
             image_utils.paste_image(rendered_images[i], canvas, px, panel_y)
-        px = px + panel_width + spacer
+        px = int(px + panel_width + spacer)
     # and the merged image
     if show_top_labels:
         if (merged_names):

--- a/omero/figure_scripts/ROI_Split_Figure.py
+++ b/omero/figure_scripts/ROI_Split_Figure.py
@@ -543,7 +543,8 @@ def get_split_view(conn, image_ids, pixel_ids, split_indexes, channel_names,
         image_utils.paste_image(image, figure_canvas, int(left_text_width),
                                 int(row_y + top_spacers[row]))
         x = left_text_width + width + spacer
-        image_utils.paste_image(roi_split_panes[row], figure_canvas, x, row_y)
+        image_utils.paste_image(roi_split_panes[row], figure_canvas,
+                                int(x), int(row_y))
         row_y = row_y + max(image.size[1] + top_spacers[row],
                             roi_split_panes[row].size[1]) + spacer
 

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -685,7 +685,7 @@ def run_script():
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
     ckeys = list(COLOURS.keys())
     ckeys.sort()
-    o_colours = wrap(OVERLAY_COLOURS.keys())
+    o_colours = wrap(list(OVERLAY_COLOURS.keys()))
 
     client = scripts.client(
         'Split_View_Figure.py',

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -683,7 +683,7 @@ def run_script():
     labels = [rstring('Image Name'), rstring('Datasets'), rstring('Tags')]
     algorithms = [rstring('Maximum Intensity'), rstring('Mean Intensity')]
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
-    ckeys = COLOURS.keys()
+    ckeys = list(COLOURS.keys())
     ckeys.sort()
     o_colours = wrap(OVERLAY_COLOURS.keys())
 

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -62,11 +62,6 @@ def log(text):
     """
     Adds the text to a list of logs. Compiled into figure legend at the end.
     """
-    # Handle unicode
-    try:
-        text = text.encode('utf8')
-    except UnicodeEncodeError:
-        pass
     log_strings.append(text)
 
 
@@ -273,7 +268,7 @@ def get_split_view(conn, pixel_ids, z_start, z_end, split_indexes,
         canvas = Image.new(mode, size, white)
 
         px = spacer
-        py = spacer/2
+        py = spacer//2
         col = 0
         # paste the images in
         for img in rendered_images:
@@ -314,7 +309,7 @@ def get_split_view(conn, pixel_ids, z_start, z_end, split_indexes,
     figure_size = (total_width, total_height+spacer)
     figure_canvas = Image.new(mode, figure_size, white)
 
-    row_y = spacer/2
+    row_y = spacer // 2
     for row in row_panels:
         image_utils.paste_image(row, figure_canvas, 0, row_y)
         row_y = row_y + row.size[1]
@@ -377,7 +372,7 @@ def make_split_view_figure(conn, pixel_ids, z_start, z_end, split_indexes,
     elif width > 200:
         fontsize = 16
 
-    spacer = (width/25) + 2
+    spacer = (width // 25) + 2
     text_gap = 3        # gap between text and image panels
     left_text_width = 0
     text_height = 0
@@ -413,7 +408,7 @@ def make_split_view_figure(conn, pixel_ids, z_start, z_end, split_indexes,
             for l, label in enumerate(row):
                 py = py - text_height    # find the top of this row
                 w = textdraw.textsize(label, font=font)[0]
-                inset = int((height - w) / 2)
+                inset = int((height - w) // 2)
                 textdraw.text((px+inset, py), label, font=font,
                               fill=(0, 0, 0))
                 py = py - text_gap    # add space between rows
@@ -449,7 +444,7 @@ def make_split_view_figure(conn, pixel_ids, z_start, z_end, split_indexes,
     for index in split_indexes:
         # calculate the position of the text, centered above the image
         w = font.getsize(channel_names[index])[0]
-        inset = int((width - w) / 2)
+        inset = int((width - w) // 2)
         # text is coloured if channel is grey AND in the merged image
         rgba = (0, 0, 0, 255)
         if index in merged_indexes:
@@ -472,12 +467,12 @@ def make_split_view_figure(conn, pixel_ids, z_start, z_end, split_indexes,
                     rgba = (0, 0, 0, 255)  # needs to be black!
             name = channel_names[index]
             comb_text_width = font.getsize(name)[0]
-            inset = int((width - comb_text_width) / 2)
+            inset = int((width - comb_text_width) // 2)
             draw.text((px + inset, py), name, font=font, fill=rgba)
             py = py - text_height
     else:
         comb_text_width = font.getsize("Merged")[0]
-        inset = int((width - comb_text_width) / 2)
+        inset = int((width - comb_text_width) // 2)
         px = px + inset
         draw.text((px, py), "Merged", font=font, fill=(0, 0, 0))
 
@@ -507,16 +502,16 @@ def split_view_figure(conn, script_params):
     # function for getting image labels.
     def get_image_names(full_name, tags_list, pd_list):
         name = full_name.split("/")[-1]
-        return [name.decode('utf8')]
+        return [name]
 
     # default function for getting labels is getName (or use datasets / tags)
     if script_params["Image_Labels"] == "Datasets":
         def get_datasets(name, tags_list, pd_list):
-            return [dataset.decode('utf8') for project, dataset in pd_list]
+            return [dataset for project, dataset in pd_list]
         get_labels = get_datasets
     elif script_params["Image_Labels"] == "Tags":
         def get_tags(name, tags_list, pd_list):
-            return [t.decode('utf8') for t in tags_list]
+            return [t for t in tags_list]
         get_labels = get_tags
     else:
         get_labels = get_image_names
@@ -595,7 +590,7 @@ def split_view_figure(conn, script_params):
         c_name_map = script_params["Channel_Names"]
         for c in c_name_map:
             index = int(c)
-            channel_names[index] = c_name_map[c].decode('utf8')
+            channel_names[index] = c_name_map[c]
 
     merged_indexes = []  # the channels in the combined image,
     merged_colours = {}
@@ -613,7 +608,7 @@ def split_view_figure(conn, script_params):
             merged_indexes.append(c_index)
         merged_indexes.sort()
     else:
-        merged_indexes = range(size_c)
+        merged_indexes = list(range(size_c))
 
     colour_channels = not script_params["Split_Panels_Grey"]
 

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -33,19 +33,24 @@ project.
 @since 3.0
 
 """
+from io import BytesIO
 import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 import omero.util.script_utils as script_utils
-from omero.rtypes import rlong, rstring, robject
+from omero.rtypes import rlong, rstring, robject, rint
 import omero.util.image_utils as image_utils
 from omero.constants.namespaces import NSCREATED
 import os
 
 try:
-    from PIL import Image, ImageDraw  # see ticket:2597
+    from PIL import Image, ImageDraw, ImageFont
 except ImportError:
     import Image
     import ImageDraw  # see ticket:2597
+    import ImageFont
+
+from omero.gateway import THISPATH as GATEWAYPATH
+
 
 WHITE = (255, 255, 255)
 
@@ -57,11 +62,160 @@ def log(text):
     Adds lines of text to the log_lines list, so they can be collected into a
     figure legend.
     """
-    try:
-        text = text.encode('utf8')
-    except UnicodeEncodeError:
-        pass
     log_lines.append(text)
+
+
+def paste_image(image, canvas, x, y):
+    """
+    Pastes the image onto the canvas at the specified coordinates
+    Image and canvas are instances of PIL 'Image'
+
+    @param image:		The PIL image to be pasted. Image
+    @param canvas:		The PIL image on which to paste. Image
+    @param x:			X coordinate (left) to paste
+    @param y: 			Y coordinate (top) to paste
+    """
+
+    x = int(x)
+    y = int(y)
+    x_right = image.size[0] + x
+    y_bottom = image.size[1] + y
+    # make a tuple of topleft-x, topleft-y, bottomRight-x, bottomRight-y
+    pastebox = (x, y, x_right, y_bottom)
+    canvas.paste(image, pastebox)
+
+
+def get_font(fontsize):
+    """
+    Returns a PIL ImageFont Sans-serif true-type font of the specified size
+    or a pre-compiled font of fixed size if the ttf font is not found
+
+    @param fontsize:	The size of the font you want
+    @return: 	A PIL Font
+    """
+
+    font_path = os.path.join(GATEWAYPATH, "pilfonts", "FreeSans.ttf")
+    try:
+        font = ImageFont.truetype(font_path, fontsize)
+    except:
+        font = ImageFont.load('%s/pilfonts/B%0.2d.pil' % (GATEWAYPATH, 24))
+    return font
+
+
+def paint_thumbnail_grid(thumbnail_store, length, spacing, pixel_ids,
+                         col_count, bg=(255, 255, 255), left_label=None,
+                         text_color=(0, 0, 0), fontsize=None, top_label=None):
+    """
+    Retrieves thumbnails for each pixelId, and places them in a grid,
+    with White background.
+    Option to add a vertical label to the left of the canvas
+    Creates a PIL 'Image' which is returned
+
+    @param thumbnail_store:  The omero thumbnail store.
+    @param length:			 Length of longest thumbnail side, int
+    @param spacing:			 The spacing between thumbnails and around the
+                             edges. int
+    @param pixel_ids:		 List of pixel IDs. [long]
+    @param col_count:		 The number of columns. int
+    @param bg:				 Background colour as (r,g,b).
+                             Default is white (255, 255, 255)
+    @param left_label: 		 Optional string to display vertically to the left.
+    @param text_color:		 The color of the text as (r,g,b).
+                             Default is black (0, 0, 0)
+    @param fontsize:		 Size of the font.
+                             Default is calculated based on thumbnail length,
+                             int
+    @return: 			    The PIL Image canvas.
+    """
+    mode = "RGB"
+    # work out how many rows and columns are needed for all the images
+    img_count = len(pixel_ids)
+
+    row_count = img_count // col_count
+    # check that we have enough rows and cols...
+    while (col_count * row_count) < img_count:
+        row_count += 1
+
+    left_space = top_space = spacing
+    min_width = 0
+
+    text_height = 0
+    if left_label or top_label:
+        # if no images (no rows), need to make at least one row to show label
+        if left_label is not None and row_count == 0:
+            row_count = 1
+        if fontsize is None:
+            fontsize = (length // 10) + 5
+        font = get_font(fontsize)
+        if left_label:
+            text_width, text_height = font.getsize(left_label)
+            left_space = spacing + text_height + spacing
+        if top_label:
+            text_width, text_height = font.getsize(top_label)
+            top_space = spacing + text_height + spacing
+            min_width = left_space + text_width + spacing
+
+    # work out the canvas size needed, and create a white canvas
+    cols_needed = min(col_count, img_count)
+    v = left_space + cols_needed * (length + spacing)
+    canvas_width = int(max(min_width, v))
+    canvas_height = int(top_space + row_count * (length + spacing) + spacing)
+    mode = "RGB"
+    size = (canvas_width, canvas_height)
+    canvas = Image.new(mode, size, bg)
+
+    # to write text up the left side, need to write it on horizontal canvas
+    # and rotate.
+    if left_label:
+        label_canvas_width = canvas_height
+        label_canvas_height = text_height + spacing
+        label_size = (label_canvas_width, label_canvas_height)
+        text_canvas = Image.new(mode, label_size, bg)
+        draw = ImageDraw.Draw(text_canvas)
+        text_width = font.getsize(left_label)[0]
+        text_x = (label_canvas_width - text_width) // 2
+        draw.text((text_x, spacing), left_label, font=font, fill=text_color)
+        vertical_canvas = text_canvas.rotate(90)
+        paste_image(vertical_canvas, canvas, 0, 0)
+        del draw
+
+    if top_label is not None:
+        label_canvas_width = canvas_width
+        label_canvas_height = text_height + spacing
+        label_size = (label_canvas_width, label_canvas_height)
+        text_canvas = Image.new(mode, label_size, bg)
+        draw = ImageDraw.Draw(text_canvas)
+        draw.text((spacing, spacing), top_label, font=font, fill=text_color)
+        paste_image(text_canvas, canvas, left_space, 0)
+        del draw
+
+    # loop through the images, getting a thumbnail and placing it on a new row
+    # and column
+    r = 0
+    c = 0
+    thumbnail_map = thumbnail_store.getThumbnailByLongestSideSet(rint(length),
+                                                                 pixel_ids)
+    for pixels_id in pixel_ids:
+        if pixels_id in thumbnail_map:
+            thumbnail = thumbnail_map[pixels_id]
+            # check we have a thumbnail (won't get one if image is invalid)
+            if thumbnail:
+                # make an "Image" from the string-encoded thumbnail
+                thumb_image = Image.open(BytesIO(thumbnail))
+                # paste the image onto the canvas at the correct coordinates
+                # for the current row and column
+                x = c * (length + spacing) + left_space
+                y = r * (length + spacing) + top_space
+                paste_image(thumb_image, canvas, x, y)
+
+        # increment the column, and if we're at the last column, start a new
+        # row
+        c = c + 1
+        if c == col_count:
+            c = 0
+            r = r + 1
+
+    return canvas
 
 
 def sort_images_by_tag(tag_ids, img_tags):
@@ -237,7 +391,7 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
                 % (tag_string, len(tagset_pix_ids)))
             if not show_subset_labels:
                 tag_string = None
-            sub_canvas = image_utils.paint_thumbnail_grid(
+            sub_canvas = paint_thumbnail_grid(
                 thumbnail_store, length,
                 spacing, tagset_pix_ids, col_count, top_label=tag_string)
             tag_sub_panes.append(sub_canvas)
@@ -282,7 +436,7 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
             p_x = left_spacer
             p_y = 0
             for pane in tag_sub_panes:
-                image_utils.paste_image(pane, tag_canvas, p_x, p_y)
+                paste_image(pane, tag_canvas, p_x, p_y)
                 p_y += pane.size[1]
             if tag_text is not None:
                 draw = ImageDraw.Draw(tag_canvas)
@@ -301,7 +455,7 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
         for image_id in ds_image_ids:
             log("  Name: %s  ID: %d" % (image_names[image_id], image_id))
             pixel_ids.append(image_pixel_map[image_id])
-        fig_canvas = image_utils.paint_thumbnail_grid(
+        fig_canvas = paint_thumbnail_grid(
             thumbnail_store, length, spacing, pixel_ids, col_count)
         tag_panes.append(fig_canvas)
 
@@ -310,12 +464,12 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
     max_width = max([c.size[0] for c in tag_panes])
     total_height = total_height + sum([c.size[1]+tagset_spacer
                                       for c in tag_panes]) - tagset_spacer
-    size = (max_width, total_height)
+    size = (int(max_width), int(total_height))
     full_canvas = Image.new(mode, size, WHITE)
     p_x = 0
     p_y = top_spacer
     for pane in tag_panes:
-        image_utils.paste_image(pane, full_canvas, p_x, p_y)
+        paste_image(pane, full_canvas, p_x, p_y)
         p_y += pane.size[1] + tagset_spacer
 
     # create dates for the image timestamps. If dates are not the same, show
@@ -399,7 +553,11 @@ def make_thumbnail_figure(conn, script_params):
             log("Dataset: %s     ID: %d"
                 % (dataset.getName(), dataset.getId()))
             images = list(dataset.listChildren())
-            title = dataset.getName().decode('utf8')
+            title = dataset.getName()
+            try:
+                title = title.decode('utf8')
+            except AttributeError:
+                pass    # python 3
             ds_canvas = paint_dataset_canvas(
                 conn, images, title, tag_ids, show_untagged,
                 length=thumb_size, col_count=max_columns)
@@ -423,7 +581,7 @@ def make_thumbnail_figure(conn, script_params):
     figure = Image.new("RGB", (fig_width, fig_height), WHITE)
     y = 0
     for ds in ds_canvases:
-        image_utils.paste_image(ds, figure, 0, y)
+        paste_image(ds, figure, 0, y)
         y += ds.size[1]
 
     log("")

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -96,7 +96,7 @@ def get_font(fontsize):
     font_path = os.path.join(GATEWAYPATH, "pilfonts", "FreeSans.ttf")
     try:
         font = ImageFont.truetype(font_path, fontsize)
-    except:
+    except OSError:
         font = ImageFont.load('%s/pilfonts/B%0.2d.pil' % (GATEWAYPATH, 24))
     return font
 

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -37,7 +37,7 @@ from io import BytesIO
 import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 import omero.util.script_utils as script_utils
-from omero.rtypes import rlong, rstring, robject, rint
+from omero.rtypes import rint, rlong, rstring, robject
 from omero.constants.namespaces import NSCREATED
 import os
 
@@ -69,17 +69,17 @@ def paste_image(image, canvas, x, y):
     Pastes the image onto the canvas at the specified coordinates
     Image and canvas are instances of PIL 'Image'
 
-    @param image:		The PIL image to be pasted. Image
-    @param canvas:		The PIL image on which to paste. Image
-    @param x:			X coordinate (left) to paste
-    @param y: 			Y coordinate (top) to paste
+    @param image:       The PIL image to be pasted. Image
+    @param canvas:      The PIL image on which to paste. Image
+    @param x:           X coordinate (left) to paste
+    @param y:           Y coordinate (top) to paste
     """
 
     x = int(x)
     y = int(y)
     x_right = image.size[0] + x
     y_bottom = image.size[1] + y
-    # make a tuple of topleft-x, topleft-y, bottomRight-x, bottomRight-y
+    # make a tuple of topLeft-x, topLeft-y, bottomRight-x, bottomRight-y
     pastebox = (x, y, x_right, y_bottom)
     canvas.paste(image, pastebox)
 
@@ -110,21 +110,21 @@ def paint_thumbnail_grid(thumbnail_store, length, spacing, pixel_ids,
     Option to add a vertical label to the left of the canvas
     Creates a PIL 'Image' which is returned
 
-    @param thumbnail_store:  The omero thumbnail store.
-    @param length:			 Length of longest thumbnail side, int
-    @param spacing:			 The spacing between thumbnails and around the
-                             edges. int
-    @param pixel_ids:		 List of pixel IDs. [long]
-    @param col_count:		 The number of columns. int
-    @param bg:				 Background colour as (r,g,b).
-                             Default is white (255, 255, 255)
-    @param left_label: 		 Optional string to display vertically to the left.
-    @param text_color:		 The color of the text as (r,g,b).
-                             Default is black (0, 0, 0)
-    @param fontsize:		 Size of the font.
-                             Default is calculated based on thumbnail length,
-                             int
-    @return: 			    The PIL Image canvas.
+    @param thumbnail_store: The omero thumbnail store.
+    @param length:          Length of longest thumbnail side, int
+    @param spacing:         The spacing between thumbnails and around the
+                            edges. int
+    @param pixel_ids:       List of pixel IDs. [long]
+    @param col_count:       The number of columns. int
+    @param bg:              Background colour as (r,g,b).
+                            Default is white (255, 255, 255)
+    @param left_label:      Optional string to display vertically to the left.
+    @param text_color:      The color of the text as (r,g,b).
+                            Default is black (0, 0, 0)
+    @param fontsize:        Size of the font.
+                            Default is calculated based on thumbnail length,
+                            int
+    @return:                The PIL Image canvas.
     """
     mode = "RGB"
     # work out how many rows and columns are needed for all the images

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -92,7 +92,7 @@ def get_font(fontsize):
     @param fontsize:	The size of the font you want
     @return: 	A PIL Font
     """
-
+    fontsize = int(fontsize)
     font_path = os.path.join(GATEWAYPATH, "pilfonts", "FreeSans.ttf")
     try:
         font = ImageFont.truetype(font_path, fontsize)
@@ -269,7 +269,7 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
 
     mode = "RGB"
     fig_canvas = None
-    spacing = length/40 + 2
+    spacing = length//40 + 2
 
     thumbnail_store = conn.createThumbnailStore()
     metadata_service = conn.getMetadataService()
@@ -329,8 +329,7 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
             for tag in tags:
                 tag_id = tag.getId().getValue()
                 # make a dict of tag-names
-                val = tag.getTextValue().getValue()
-                tag_names[tag_id] = val.decode('utf8')
+                tag_names[tag_id] = tag.getTextValue().getValue()
                 img_tag_ids.append(tag_id)
             img_tags[image_id] = img_tag_ids
 

--- a/omero/figure_scripts/Thumbnail_Figure.py
+++ b/omero/figure_scripts/Thumbnail_Figure.py
@@ -38,7 +38,6 @@ import omero.scripts as scripts
 from omero.gateway import BlitzGateway
 import omero.util.script_utils as script_utils
 from omero.rtypes import rlong, rstring, robject, rint
-import omero.util.image_utils as image_utils
 from omero.constants.namespaces import NSCREATED
 import os
 
@@ -300,7 +299,7 @@ def paint_dataset_canvas(conn, images, title, tag_ids=None,
 
     # set-up fonts
     fontsize = length/7 + 5
-    font = image_utils.get_font(fontsize)
+    font = get_font(fontsize)
     text_height = font.getsize("Textq")[1]
     top_spacer = spacing + text_height
     left_spacer = spacing + text_height

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -31,11 +31,6 @@ import omero.model
 import sys
 
 from omero.util.populate_roi import DownloadingOriginalFileProvider
-try:
-    long
-except Exception:
-    # Python 3
-    long = int
 
 try:
     # Hopefully this will import
@@ -92,7 +87,7 @@ def populate_metadata(client, conn, script_params):
     object_id = object_ids[0]
     file_ann_id = None
     if "File_Annotation" in script_params:
-        file_ann_id = long(script_params["File_Annotation"])
+        file_ann_id = int(script_params["File_Annotation"])
     data_type = script_params["Data_Type"]
     original_file = get_original_file(
         conn, data_type, object_id, file_ann_id)
@@ -100,7 +95,7 @@ def populate_metadata(client, conn, script_params):
     data_for_preprocessing = provider.get_original_file_data(original_file)
     data = provider.get_original_file_data(original_file)
     objecti = getattr(omero.model, data_type + 'I')
-    omero_object = objecti(long(object_id), False)
+    omero_object = objecti(int(object_id), False)
     ctx = ParsingContext(client, omero_object, "")
 
     try:

--- a/omero/util_scripts/Dataset_To_Plate.py
+++ b/omero/util_scripts/Dataset_To_Plate.py
@@ -36,11 +36,6 @@ from omero.gateway import BlitzGateway
 import omero
 
 from omero.rtypes import rint, rlong, rstring, robject, unwrap
-try:
-    long
-except Exception:
-    # Python 3
-    long = int
 
 
 def add_images_to_plate(conn, images, plate_id, column, row, remove_from=None):

--- a/test/integration/script.py
+++ b/test/integration/script.py
@@ -139,6 +139,6 @@ def get_file_contents(client, original_file_id):
     """Returns Original File contents as a string."""
     conn = BlitzGateway(client_obj=client)
     orig_file = conn.getObject("OriginalFile", original_file_id)
-    text = "".join(orig_file.getFileInChunks())
+    text = b"".join(orig_file.getFileInChunks())
     conn.close()
-    return text
+    return text.decode('utf-8')


### PR DESCRIPTION
Fixes figure scripts for python 3.

To test:
 - Use the figure scripts from webclient with custom UI:
     - Thumbnail Figure
     - Split-View Figure
     - Make Movie
- And from scripts menu: Movie ROI Figure
 

This ports some code from ```image_util``` to fix it in the script itself.

```paint_thumbnail_grid``` isn't used by any other code and could be deprecated/removed from ```image_utils.py```