### PR TITLE
Add infrastructure for releasing omero-scripts to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: python
 
 sudo: required
@@ -6,7 +7,14 @@ services:
   - docker
 
 before_install:
-  - git clone --recurse-submodules git://github.com/openmicroscopy/omero-test-infra .omero
+  - git clone git://github.com/ome/omero-test-infra .omero
 
 script:
   - .omero/docker scripts
+
+deploy:
+  provider: pypi
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     packages=[
         'omero.analysis_scripts',
         'omero.export_scripts',
+        'omero.figure_scripts',
         'omero.import_scripts',
         'omero.util_scripts'],
     description="OMERO scripts",

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ class PyTest(test_command):
         sys.exit(errno)
 
 
-version = '5.5.2.dev'
-url = "https://github.com/ome/scripts/"
+version = '5.6.dev1'
+url = "https://github.com/ome/omero-scripts/"
 
 setup(
     version=version,


### PR DESCRIPTION
Follow-up of #163,

- fixes the packaging of the `figure_scripts`
- bumps the version number to a PEP440 compliant pre-release
- adds the classical PyPI deployment section to Travis YML
- the repository was renamed from `ome/scripts` as `ome/omero-scripts`

This PR should be tested by the CI builds in conjunction with https://github.com/ome/openmicroscopy/pull/6190 which updates the OMERO bundle build system to unpack the `omero-scripts` source distribution archive rather than the GitHub archive. All script-released integration tests are expected to keep passing. 

Assuming tests are green, this project should be releasable as a PyPI pre-release. Once available, https://github.com/ome/openmicroscopy/pull/6190 can be updated to consume the pre-release like other Python components.