### PR TITLE
ROI export handle points whitespace

### DIFF
--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -194,7 +194,7 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
             coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
                       for coord in coords]
         except ValueError:
-            print("Invalid Polyline coords:", coords)
+            log("Invalid Polyline coords: %s" % coords)
         else:
             lengths = []
             for i in range(len(coords)-1):
@@ -211,7 +211,7 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
             coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
                       for coord in coords]
         except ValueError:
-            print("Invalid Polygon coords:", coords)
+            log("Invalid Polygon coords: %s" % coords)
         else:
             total = 0
             for c in range(len(coords)):

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -192,7 +192,7 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
         coords = point_list.strip(" ").split(" ")
         try:
             coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
-                    for coord in coords]
+                      for coord in coords]
         except ValueError:
             print("Invalid Polyline coords:", coords)
         else:
@@ -216,8 +216,8 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
             total = 0
             for c in range(len(coords)):
                 coord = coords[c]
-                next_coord = coords[(c + 1) % len(coords)]
-                total += (coord[0] * next_coord[1]) - (next_coord[0] * coord[1])
+                next_c = coords[(c + 1) % len(coords)]
+                total += (coord[0] * next_c[1]) - (next_c[0] * coord[1])
             row_data['area'] = abs(0.5 * total)
     if 'area' in row_data and pixel_size_x and pixel_size_y:
         row_data['area'] = row_data['area'] * pixel_size_x * pixel_size_y

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -189,28 +189,36 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y):
             point_list = match.group(1)
         row_data['Points'] = '"%s"' % point_list
     if isinstance(shape, PolylineI):
-        coords = point_list.split(" ")
-        coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
-                  for coord in coords]
-        lengths = []
-        for i in range(len(coords)-1):
-            dx = (coords[i][0] - coords[i + 1][0])
-            dy = (coords[i][1] - coords[i + 1][1])
-            dx = dx if pixel_size_x is None else dx * pixel_size_x
-            dy = dy if pixel_size_y is None else dy * pixel_size_y
-            lengths.append(sqrt((dx * dx) + (dy * dy)))
-        row_data['length'] = sum(lengths)
+        coords = point_list.strip(" ").split(" ")
+        try:
+            coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
+                    for coord in coords]
+        except ValueError:
+            print("Invalid Polyline coords:", coords)
+        else:
+            lengths = []
+            for i in range(len(coords)-1):
+                dx = (coords[i][0] - coords[i + 1][0])
+                dy = (coords[i][1] - coords[i + 1][1])
+                dx = dx if pixel_size_x is None else dx * pixel_size_x
+                dy = dy if pixel_size_y is None else dy * pixel_size_y
+                lengths.append(sqrt((dx * dx) + (dy * dy)))
+            row_data['length'] = sum(lengths)
     if isinstance(shape, PolygonI):
         # https://www.mathopenref.com/coordpolygonarea.html
-        coords = point_list.split(" ")
-        coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
-                  for coord in coords]
-        total = 0
-        for c in range(len(coords)):
-            coord = coords[c]
-            next_coord = coords[(c + 1) % len(coords)]
-            total += (coord[0] * next_coord[1]) - (next_coord[0] * coord[1])
-        row_data['area'] = abs(0.5 * total)
+        coords = point_list.strip(" ").split(" ")
+        try:
+            coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
+                      for coord in coords]
+        except ValueError:
+            print("Invalid Polygon coords:", coords)
+        else:
+            total = 0
+            for c in range(len(coords)):
+                coord = coords[c]
+                next_coord = coords[(c + 1) % len(coords)]
+                total += (coord[0] * next_coord[1]) - (next_coord[0] * coord[1])
+            row_data['area'] = abs(0.5 * total)
     if 'area' in row_data and pixel_size_x and pixel_size_y:
         row_data['area'] = row_data['area'] * pixel_size_x * pixel_size_y
 


### PR DESCRIPTION
Found this bug when trying Batch_ROI_Export from outreach server, using idr0022 data.
Failed with ```float(x.strip(", ")``` since points string was not in the exact expected format.

I now strip whitespace before split(' ') so don't end up with empty string from trailing whitespace.
Also wrap with try/except in case some other unexpected format - Don't want a single invalid
points list to break the whole script.

To test:
 - Upload script to e.g. outreach server and try Batch_ROI_Export on idr0021 data.