### PR TITLE
ROI export with Well ID

### DIFF
--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -120,13 +120,15 @@ def get_export_data(conn, script_params, image, units=None):
                             "mean": stats[0].mean[c] if stats else "",
                             "std_dev": stats[0].stdDev[c] if stats else ""
                         }
+                        if hasattr(image, 'well_id'):
+                            row_data['well_id'] = image.well_id
                         add_shape_coords(shape, row_data,
                                          pixel_size_x, pixel_size_y)
                         export_data.append(row_data)
 
     return export_data
 
-
+# well_id inserted if SPW
 COLUMN_NAMES = ["image_id",
                 "image_name",
                 "roi_id",
@@ -251,7 +253,9 @@ def get_images_from_plate(plate):
     imgs = []
     for well in plate.listChildren():
         for ws in well.listChildren():
-            imgs.append(ws.image())
+            img = ws.image()
+            img.well_id = well.id
+            imgs.append(img)
     return imgs
 
 
@@ -261,6 +265,8 @@ def batch_roi_export(conn, script_params):
 
     dtype = script_params['Data_Type']
     ids = script_params['IDs']
+    if dtype in ("Screen", "Plate"):
+        COLUMN_NAMES.insert(1, "well_id")
     if dtype == "Image":
         images = list(conn.getObjects("Image", ids))
     elif dtype == "Dataset":

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -317,11 +317,11 @@ def batch_roi_export(conn, script_params):
 
     row_count = 0
     with open(file_name, 'w') as csv_file:
-        csv_file.write(csv_header + "\n")
+        csv_file.write(csv_header)
         for image in images:
             for row in get_export_data(conn, script_params, image, units):
                 cells = [str(row.get(name, "")) for name in COLUMN_NAMES]
-                csv_file.write(",".join(cells) + "\n")
+                csv_file.write("\n" + ",".join(cells))
                 row_count += 1
 
     file_ann = conn.createFileAnnfromLocalFile(file_name, mimetype="text/csv")

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -368,7 +368,7 @@ def run_script():
             "Include_Points_Coords", grouping="5",
             description=("Export the Points string for Polygons "
                          "and Polylines. Disable this to reduce the "
-                         "size of the csv file when exporting large "
+                         "size of the CSV file when exporting large "
                          "numbers of ROIs"),
             default=True),
 

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -78,6 +78,16 @@ def get_export_data(conn, script_params, image, units=None):
     rois.sort(key=lambda r: r.id.val)
     export_data = []
 
+    well_id = None
+    # For SPW data, add Well info...
+    if image._obj.wellSamplesLoaded:
+        for well_sample in image.copyWellSamples():
+            well_id = well_sample.getWell().id.val
+            well = conn.getObject("Well", well_id)
+            well_row = well.getRow()
+            well_column = well.getColumn()
+            well_label = well.getWellPos()
+
     for roi in rois:
         for shape in roi.copyShapes():
             label = unwrap(shape.getTextValue())
@@ -122,14 +132,11 @@ def get_export_data(conn, script_params, image, units=None):
                             "std_dev": stats[0].stdDev[c] if stats else ""
                         }
                         # For SPW data, add Well info...
-                        if image._obj.wellSamplesLoaded:
-                            for well_sample in image.copyWellSamples():
-                                w = well_sample.getWell()
-                                well = conn.getObject("Well", w.id.val)
-                                row_data['well_id'] = w.id.val
-                                row_data['well_row'] = well.getRow()
-                                row_data['well_column'] = well.getColumn()
-                                row_data['well_label'] = well.getWellPos()
+                        if well_id is not None:
+                            row_data['well_id'] = well_id
+                            row_data['well_row'] = well_row
+                            row_data['well_column'] = well_column
+                            row_data['well_label'] = well_label
                         add_shape_coords(shape, row_data,
                                          pixel_size_x, pixel_size_y,
                                          include_points)

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -120,11 +120,10 @@ def get_export_data(conn, script_params, image, units=None):
                             "mean": stats[0].mean[c] if stats else "",
                             "std_dev": stats[0].stdDev[c] if stats else ""
                         }
-                        if hasattr(image, 'well_id'):
-                            row_data['well_id'] = image.well_id
+                        # For SPW data, add Well info...
                         if image._obj.wellSamplesLoaded:
-                            for wellSample in image.copyWellSamples():
-                                w = wellSample.getWell()
+                            for well_sample in image.copyWellSamples():
+                                w = well_sample.getWell()
                                 well = conn.getObject("Well", w.id.val)
                                 row_data['well_id'] = w.id.val
                                 row_data['well_row'] = well.getRow()
@@ -135,6 +134,7 @@ def get_export_data(conn, script_params, image, units=None):
                         export_data.append(row_data)
 
     return export_data
+
 
 # well_id, well_row, well_column, well_label inserted if SPW
 COLUMN_NAMES = ["image_id",

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -177,7 +177,7 @@ COLUMN_NAMES = ["image_id",
 
 
 def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y,
-                     include_points=False):
+                     include_points=True):
     """Add shape coordinates and length or area to the row_data dict."""
     if shape.getTextValue():
         row_data['Text'] = shape.getTextValue().getValue()

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -146,6 +146,7 @@ def get_export_data(conn, script_params, image, units=None):
 
 
 # well_id, well_row, well_column, well_label inserted if SPW
+# Points inserted if exporting shape points string
 COLUMN_NAMES = ["image_id",
                 "image_name",
                 "roi_id",
@@ -172,8 +173,7 @@ COLUMN_NAMES = ["image_id",
                 "X1",
                 "Y1",
                 "X2",
-                "Y2",
-                "Points"]
+                "Y2"]
 
 
 def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y,
@@ -280,6 +280,8 @@ def batch_roi_export(conn, script_params):
         COLUMN_NAMES.insert(2, "well_row")
         COLUMN_NAMES.insert(3, "well_column")
         COLUMN_NAMES.insert(4, "well_label")
+    if script_params.get("Include_Points_Coords", False):
+        COLUMN_NAMES.append("Points")
     if dtype == "Image":
         images = list(conn.getObjects("Image", ids))
     elif dtype == "Dataset":


### PR DESCRIPTION
When exporting ROIs to csv from SPW data, it is useful to include Well ID (and Well row, column and label).
This also adds the option to NOT export the Points coordinates string, which can cause a big increase in the size of the csv file.

This was needed for OMERO.parade prototype demo at https://youtu.be/FyjGhZxx6es?t=899

To test:
 - Export ROIs for a Screen or Plate.
 - Check that the CSV has columns for Well ID, row, column and label.
 - Check that un-checking the "Include_Points_Coords" option exports CSV without Points values.