### PR TITLE
Add Include_Points_Coords param to Batch_ROI_Export

### DIFF
--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -192,10 +192,12 @@ def add_shape_coords(shape, row_data, pixel_size_x, pixel_size_y,
             point_list = match.group(1)
         if include_points:
             row_data['Points'] = '"%s"' % point_list
-    if isinstance(shape, (PolygonI, PolylineI)):
         coords = point_list.split(" ")
         coords = [[float(x.strip(", ")) for x in coord.split(",", 1)]
                   for coord in coords]
+        # to measure length of Polygon, add length to start point
+        if isinstance(shape, PolygonI):
+            coords.append(coords[0])
         lengths = []
         for i in range(len(coords)-1):
             dx = (coords[i][0] - coords[i + 1][0])

--- a/test/integration/test_export_scripts.py
+++ b/test/integration/test_export_scripts.py
@@ -134,6 +134,8 @@ class TestExportScripts(ScriptTest):
                     "%s,\"%s\",%s,%s,polygon,\"%s\",%s,0,%s,%s,%s,") % (
             image.id.val, image_name, roi.id.val, polygon.id.val,
             label_text, zt, area, length, points_min_max_sum_mean)
+        print('csv_text', csv_text)
+        print('expected', expected)
         assert csv_text.startswith(expected)
 
     @pytest.mark.broken(

--- a/test/integration/test_export_scripts.py
+++ b/test/integration/test_export_scripts.py
@@ -123,7 +123,7 @@ class TestExportScripts(ScriptTest):
         zt = ","
         points_min_max_sum_mean = ",,,,"
         area = "6561.0"
-        length = "324"
+        length = "324.0"
         if all_planes:
             zt = "1,1"
             points_min_max_sum_mean = "6561,10.0,90.0,328050.0,50.0"

--- a/test/integration/test_export_scripts.py
+++ b/test/integration/test_export_scripts.py
@@ -123,6 +123,7 @@ class TestExportScripts(ScriptTest):
         zt = ","
         points_min_max_sum_mean = ",,,,"
         area = "6561.0"
+        length = "324"
         if all_planes:
             zt = "1,1"
             points_min_max_sum_mean = "6561,10.0,90.0,328050.0,50.0"
@@ -130,9 +131,9 @@ class TestExportScripts(ScriptTest):
                     "z,t,channel,area (pixels),length (pixels),"
                     "points,min,max,sum,mean,std_dev,"
                     "X,Y,Width,Height,RadiusX,RadiusY,X1,Y1,X2,Y2,Points\n"
-                    "%s,\"%s\",%s,%s,polygon,\"%s\",%s,0,%s,,%s,") % (
-            image.id.val, image_name, roi.id.val,
-            polygon.id.val, label_text, zt, area, points_min_max_sum_mean)
+                    "%s,\"%s\",%s,%s,polygon,\"%s\",%s,0,%s,%s,%s,") % (
+            image.id.val, image_name, roi.id.val, polygon.id.val,
+            label_text, zt, area, length, points_min_max_sum_mean)
         assert csv_text.startswith(expected)
 
     @pytest.mark.broken(


### PR DESCRIPTION
This PR Adds a ```Include_Points_Coords``` parameter to the Batch_ROI_Export. Excluding Points coords is useful when exporting large numbers of ROIs since the Points string can be much larger than all the other data in the csv.

To test:
 - Uncheck the "Include Points Coords" input parameter and check that the Points column is not populated with the Points string for Polygons/Polylines.