### PR TITLE
Plot Profile Ignore zero length lines

### DIFF
--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -60,6 +60,8 @@ def process_polylines(conn, script_params, image, polylines, line_width, fout):
             for l in range(len(points)-1):
                 x1, y1 = points[l]
                 x2, y2 = points[l+1]
+                if round(x1 - x2) == 0 and round(y1 - y2) == 0:
+                    continue
                 ld = roi_utils.get_line_data(
                     pixels, x1, y1, x2, y2, line_width,
                     the_z, the_c, the_t)

--- a/omero/analysis_scripts/Plot_Profile.py
+++ b/omero/analysis_scripts/Plot_Profile.py
@@ -105,6 +105,8 @@ def process_lines(conn, script_params, image, lines, line_width, fout):
         the_t = l['theT']
         the_z = l['theZ']
         roi_id = l['id']
+        if round(l['x1'] - l['x2']) == 0 and round(l['y1'] - l['y2']) == 0:
+            continue
         for the_c in the_cs:
             line_data = []
             line_data = roi_utils.get_line_data(pixels, l['x1'], l['y1'],

--- a/test/integration/test_analysis_scripts.py
+++ b/test/integration/test_analysis_scripts.py
@@ -82,7 +82,10 @@ class TestAnalysisScripts(ScriptTest):
         session = client.getSession()
         image = self.create_test_image(size_x, size_y, 1, 2, size_t, session)
         image_id = image.id.val
-        roi = create_roi(image_id, 0, size_x / 2, 0, size_y / 2, size_t, False)
+        roi = create_roi(image_id, 0, size_x / 2, 0, size_y / 2, size_t, True)
+        session.getUpdateService().saveAndReturnObject(roi)
+        # Test zero-length line
+        roi = create_roi(image_id, 1, 1, 1, 1, 1, False)
         session.getUpdateService().saveAndReturnObject(roi)
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image_id))
@@ -159,7 +162,8 @@ def create_roi(image_id, x1, x2, y1, y2, size_t, with_polylines):
             polyline = omero.model.PolylineI()
             polyline.theZ = omero.rtypes.rint(0)
             polyline.theT = omero.rtypes.rint(t)
-            points = [[10.5, 20], [50.55, 50], [75, 60]]
+            # Includes a zero-length section - possible with iviewer freehand
+            points = [[10.5, 20], [50.55, 50], [75, 60], [75, 60]]
             polyline.points = omero.rtypes.rstring(points_to_string(points))
             roi.addShape(polyline)
     return roi


### PR DESCRIPTION
Tiny fix to Plot_Profile script, noticed while testing https://github.com/ome/omero-py/pull/278

To test:
 - "accidentally" create a line of zero length in iviewer by dragging to draw (instead of click-move-click)
 - Run the Plot_Profile script
 - Other lines should be processed as normal