### PR TITLE
Populate metadata Image dtype

### DIFF
--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -137,7 +137,7 @@ def run_script():
     client = scripts.client(
         'Populate_Metadata.py',
         """
-    This script processes a CSV file, using it to,
+    This script processes a CSV file, using it to
     'populate' an OMERO.table, with one row per Image, Well or ROI.
     The table data can then be displayed in the OMERO clients.
     For full details of the supported CSV format, see

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -110,7 +110,7 @@ def populate_metadata(client, conn, script_params):
 
     if data_type == "Image":
         try:
-            from omero_metadata.populate import ImageWrapper
+            from omero_metadata.populate import ImageWrapper    # noqa: F401
         except ImportError:
             return "Please update omero-metadata to support Image type"
     file_ann_id = None

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -137,11 +137,11 @@ def run_script():
     client = scripts.client(
         'Populate_Metadata.py',
         """
-    This script processes a CSV file, attached to a container,
-    converting it to an OMERO.table, with one row per Image or Well.
+    This script processes a CSV file, using it to,
+    'populate' an OMERO.table, with one row per Image, Well or ROI.
     The table data can then be displayed in the OMERO clients.
     For full details of the supported CSV format, see
-    https://github.com/ome/omero-metadata/
+    https://github.com/ome/omero-metadata/#populate
         """ + DEPRECATED,
         scripts.String(
             "Data_Type", optional=False, grouping="1",

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -41,6 +41,7 @@ try:
         'Screen',
         'Dataset',
         'Project',
+        'Image',
     )
     DEPRECATED = ""
 

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -36,21 +36,20 @@ try:
     # Hopefully this will import
     # https://github.com/ome/omero-metadata/blob/v0.3.1/src/populate_metadata.py
     from omero_metadata.populate import ParsingContext
-    OBJECT_TYPES = (
+    OBJECT_TYPES = [
         'Plate',
         'Screen',
         'Dataset',
-        'Project',
-        'Image',
-    )
+        'Project'
+    ]
     DEPRECATED = ""
 
 except ImportError:
     from omero.util.populate_metadata import ParsingContext
-    OBJECT_TYPES = (
+    OBJECT_TYPES = [
         'Plate',
         'Screen',
-    )
+    ]
     DEPRECATED = """
 
     Warning: This script is using an outdated metadata plugin.
@@ -58,6 +57,14 @@ except ImportError:
     for additional features: https://pypi.org/project/omero-metadata/
     """
 
+try:
+    # If we have omero-metadata v0.6.0 or later, can support 'Image' input
+    from omero_metadata.populate import ImageWrapper
+    OBJECT_TYPES.append('Image')
+except ImportError:
+    pass
+
+OBJECT_TYPES = tuple(OBJECT_TYPES)
 
 def link_file_ann(conn, object_type, object_id, file_ann_id):
     """Link File Annotation to the Object, if not already linked."""

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -36,20 +36,21 @@ try:
     # Hopefully this will import
     # https://github.com/ome/omero-metadata/blob/v0.3.1/src/populate_metadata.py
     from omero_metadata.populate import ParsingContext
-    OBJECT_TYPES = [
+    OBJECT_TYPES = (
         'Plate',
         'Screen',
         'Dataset',
-        'Project'
-    ]
+        'Project',
+        'Image',
+    )
     DEPRECATED = ""
 
 except ImportError:
     from omero.util.populate_metadata import ParsingContext
-    OBJECT_TYPES = [
+    OBJECT_TYPES = (
         'Plate',
         'Screen',
-    ]
+    )
     DEPRECATED = """
 
     Warning: This script is using an outdated metadata plugin.
@@ -57,14 +58,6 @@ except ImportError:
     for additional features: https://pypi.org/project/omero-metadata/
     """
 
-try:
-    # If we have omero-metadata v0.6.0 or later, can support 'Image' input
-    from omero_metadata.populate import ImageWrapper
-    OBJECT_TYPES.append('Image')
-except ImportError:
-    pass
-
-OBJECT_TYPES = tuple(OBJECT_TYPES)
 
 def link_file_ann(conn, object_type, object_id, file_ann_id):
     """Link File Annotation to the Object, if not already linked."""
@@ -114,6 +107,12 @@ def populate_metadata(client, conn, script_params):
     object_ids = script_params["IDs"]
     object_id = object_ids[0]
     data_type = script_params["Data_Type"]
+
+    if data_type == "Image":
+        try:
+            from omero_metadata.populate import ImageWrapper
+        except ImportError:
+            return "Please update omero-metadata to support Image type"
     file_ann_id = None
     if "File_Annotation" in script_params:
         file_ann_id = int(script_params["File_Annotation"])


### PR DESCRIPTION
This allows the `Populate_Metadata` script UI to pick Image types.

To test:
 - Run on https://merge-ci.openmicroscopy.org/web/webclient/?show=image-39715 (csv already attached)