### PR TITLE
Hcs keyvals from csv

### DIFF
--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -136,6 +136,10 @@ def keyval_from_csv(conn, script_params):
     data_type = script_params["Data_Type"]
     ids = script_params["IDs"]
 
+    nimg_processed = 0
+    nimg_updated = 0
+    missing_names = 0
+
     for target_object in conn.getObjects(data_type, ids):
 
         # file_ann_id is Optional. If not supplied, use first .csv attached
@@ -186,6 +190,7 @@ def keyval_from_csv(conn, script_params):
 
         # create dictionaries for well/image name:object
         images_by_name, wells_by_name = get_children_by_name(target_object)
+        nimg_processed += len(images_by_name)
 
         image_index = header.index("image") if "image" in header else -1
         well_index = header.index("well") if "well" in header else -1
@@ -197,8 +202,6 @@ def keyval_from_csv(conn, script_params):
               "plate_index:", plate_index)
         rows = data[1:]
 
-        nimg_updated = 0
-        missing_names = 0
         # loop over csv rows...
         for row in rows:
             # try to find 'image', then 'well', then 'plate'
@@ -241,8 +244,8 @@ def keyval_from_csv(conn, script_params):
             if updated:
                 nimg_updated += 1
 
-    message = "Added {} kv pairs to {}/{} files".format(
-        len(header)-1, nimg_updated, len(images_by_name))
+    message = "Added kv pairs to {}/{} files".format(
+        nimg_updated, nimg_processed)
     if missing_names > 0:
         message += f". {missing_names} image names not found."
     return message
@@ -309,7 +312,7 @@ def run_script():
 
         scripts.List(
             "IDs", optional=False, grouping="2",
-            description="Plate or Screen ID.").ofType(rlong(0)),
+            description="Dataset or Plate ID(s).").ofType(rlong(0)),
 
         scripts.String(
             "File_Annotation", grouping="3",

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -205,9 +205,10 @@ def keyval_from_csv(conn, script_params):
                 else:
                     missing_names += 1
                     print("Well not found:", well_name)
-            if obj is None and plate_index > -1:
-                plate_name = row[plate_index]
-                if plate_name == target_object.name:
+            # always check that Plate name matches if it is given:
+            if data_type == "Plate" and plate_index > -1 and len(row[plate_index]) > 0:
+                assert row[plate_index] == target_object.name
+                if obj is None:
                     obj = target_object
                     print("Annotating Plate:", obj.id, plate_name)
             if obj is None:

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -150,17 +150,19 @@ def keyval_from_csv(conn, script_params):
         provider = DownloadingOriginalFileProvider(conn)
 
         # read the csv
-        file_handle = provider.get_original_file_data(original_file)
-        try:
-            delimiter = csv.Sniffer().sniff(file_handle.read(1024)).delimiter
-            print("Using delimiter: ", delimiter)
-        except Exception:
-            print("Failed to sniff delimiter, using ','")
-            delimiter = ","
-        # reset to start and read whole file...
-        file_handle.seek(0)
-        data = list(csv.reader(file_handle, delimiter=delimiter))
-        file_handle.close()
+        temp_file = provider.get_original_file_data(original_file)
+        # Needs omero-py 5.9.1 or later
+        temp_name = temp_file.name
+        with open(temp_name, 'rt', encoding='utf-8-sig') as file_handle:
+            try:
+                delimiter = csv.Sniffer().sniff(file_handle.read(1024)).delimiter
+                print("Using delimiter: ", delimiter)
+            except Exception:
+                print("Failed to sniff delimiter, using ','")
+                delimiter = ","
+            # reset to start and read whole file...
+            file_handle.seek(0)
+            data = list(csv.reader(file_handle, delimiter=delimiter))
 
         # keys are in the header row
         header = data[0]

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -158,13 +158,11 @@ def keyval_from_csv(conn, script_params):
                 delimiter = csv.Sniffer().sniff(file_handle.read(500),",;\t").delimiter
                 print("Using delimiter: ", delimiter,"  after reading 500 characters")
             except Exception:
-                 pass
                 file_handle.seek(0)
                 try:
                     delimiter = csv.Sniffer().sniff(file_handle.read(1000),",;\t").delimiter
                     print("Using delimiter: ", delimiter, "  after reading 1000 characters")
                 except Exception:
-                    pass
                     file_handle.seek(0)
                     try:
                         delimiter = csv.Sniffer().sniff(file_handle.read(2000),";,\t").delimiter

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -180,6 +180,7 @@ def keyval_from_csv(conn, script_params):
         rows = data[1:]
 
         nimg_updated = 0
+        missing_names = 0
         # loop over csv rows...
         for row in rows:
             # try to find 'image', then 'well', then 'plate'
@@ -192,6 +193,7 @@ def keyval_from_csv(conn, script_params):
                     obj = images_by_name[image_name]
                     print("Annotating Image:", obj.id, image_name)
                 else:
+                    missing_names += 1
                     print("Image not found:", image_name)
             if obj is None and well_index > -1 and len(row[well_index]) > 0:
                 well_name = row[well_index]
@@ -199,6 +201,7 @@ def keyval_from_csv(conn, script_params):
                     obj = wells_by_name[well_name]
                     print("Annotating Well:", obj.id, well_name)
                 else:
+                    missing_names += 1
                     print("Well not found:", well_name)
             if obj is None and plate_index > -1:
                 plate_name = row[plate_index]
@@ -215,8 +218,11 @@ def keyval_from_csv(conn, script_params):
             if updated:
                 nimg_updated += 1
 
-    return "Added {} kv pairs to {}/{} files  ".format(
+    message = "Added {} kv pairs to {}/{} files".format(
         len(header)-1, nimg_updated, len(images_by_name))
+    if missing_names > 0:
+        message += f". {missing_names} image names not found."
+    return message
 
 
 def annotate_object(conn, obj, header, row, cols_to_ignore):

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -171,9 +171,9 @@ def keyval_from_csv(conn, script_params):
         # create dictionaries for well/image name:object
         images_by_name, wells_by_name = get_children_by_name(target_object)
 
-        image_index = header.index("image")
-        well_index = header.index("well")
-        plate_index = header.index("plate")
+        image_index = header.index("image") if "image" in header else -1
+        well_index = header.index("well") if "well" in header else -1
+        plate_index = header.index("plate") if "plate" in header else -1
         if image_index == -1:
             # first header is the img-name column, if 'image' not found
             image_index = 0

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -217,7 +217,10 @@ def keyval_from_csv(conn, script_params):
                     print("Well not found:", well_name)
             # always check that Plate name matches if it is given:
             if data_type == "Plate" and plate_index > -1 and len(row[plate_index]) > 0:
-                assert row[plate_index] == target_object.name
+                if row[plate_index] != target_object.name:
+                    print("plate", row[plate_index],
+                          "doesn't match object", target_object.name)
+                    continue
                 if obj is None:
                     obj = target_object
                     print("Annotating Plate:", obj.id, plate_name)

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -155,18 +155,24 @@ def keyval_from_csv(conn, script_params):
         temp_name = temp_file.name
         with open(temp_name, 'rt', encoding='utf-8-sig') as file_handle:
             try:
-                delimiter = csv.Sniffer().sniff(file_handle.read(500),",;\t").delimiter
-                print("Using delimiter: ", delimiter,"  after reading 500 characters")
+                delimiter = csv.Sniffer().sniff(
+                    file_handle.read(500), ",;\t").delimiter
+                print("Using delimiter: ", delimiter,
+                      " after reading 500 characters")
             except Exception:
                 file_handle.seek(0)
                 try:
-                    delimiter = csv.Sniffer().sniff(file_handle.read(1000),",;\t").delimiter
-                    print("Using delimiter: ", delimiter, "  after reading 1000 characters")
+                    delimiter = csv.Sniffer().sniff(
+                        file_handle.read(1000), ",;\t").delimiter
+                    print("Using delimiter: ", delimiter,
+                          " after reading 1000 characters")
                 except Exception:
                     file_handle.seek(0)
                     try:
-                        delimiter = csv.Sniffer().sniff(file_handle.read(2000),";,\t").delimiter
-                        print("Using delimiter: ", delimiter, "  after reading 2000 characters")
+                        delimiter = csv.Sniffer().sniff(
+                            file_handle.read(2000), ";,\t").delimiter
+                        print("Using delimiter: ", delimiter,
+                              " after reading 2000 characters")
                     except Exception:
                         print("Failed to sniff delimiter, using ','")
                         delimiter = ","
@@ -216,7 +222,8 @@ def keyval_from_csv(conn, script_params):
                     missing_names += 1
                     print("Well not found:", well_name)
             # always check that Plate name matches if it is given:
-            if data_type == "Plate" and plate_index > -1 and len(row[plate_index]) > 0:
+            if data_type == "Plate" and plate_index > -1 and \
+                    len(row[plate_index]) > 0:
                 if row[plate_index] != target_object.name:
                     print("plate", row[plate_index],
                           "doesn't match object", target_object.name)
@@ -225,7 +232,7 @@ def keyval_from_csv(conn, script_params):
                     obj = target_object
                     print("Annotating Plate:", obj.id, plate_name)
             if obj is None:
-                msg = f"Can't find object by image, well or plate name"
+                msg = "Can't find object by image, well or plate name"
                 print(msg)
                 continue
 

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -29,69 +29,50 @@ import omero
 from omero.gateway import BlitzGateway
 from omero.rtypes import rstring, rlong
 import omero.scripts as scripts
-from omero.model import PlateI, ScreenI, DatasetI
-from omero.rtypes import *
 from omero.cmd import Delete2
 
 import sys
 import csv
 import copy
 
-# this is for downloading a temp file
-from omero.util.temp_files import create_path
-
 from omero.util.populate_roi import DownloadingOriginalFileProvider
-from omero.util.populate_metadata import ParsingContext
 
 from collections import OrderedDict
 
 
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-def get_existing_map_annotations( obj ):
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    print("getting the existing kv's")
+def get_existing_map_annotations(obj):
+    """Get all Map Annotations linked to the object"""
     ord_dict = OrderedDict()
     for ann in obj.listAnnotations():
-        if( isinstance(ann, omero.gateway.MapAnnotationWrapper) ):
+        if isinstance(ann, omero.gateway.MapAnnotationWrapper):
             kvs = ann.getValue()
-            for k,v in kvs:
+            for k, v in kvs:
                 if k not in ord_dict:
-                    ord_dict[k]=set()
+                    ord_dict[k] = set()
                 ord_dict[k].add(v)
     return ord_dict
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-def remove_map_annotations(conn, dtype, Id ):
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    image = conn.getObject(dtype,int(Id))
-    namespace = omero.constants.metadata.NSCLIENTMAPANNOTATION
 
-    filename = image.getName()
-
-    anns = list( image.listAnnotations())
+def remove_map_annotations(conn, object):
+    """Remove ALL Map Annotations on the object"""
+    anns = list(object.listAnnotations())
     mapann_ids = [ann.id for ann in anns
-         if isinstance(ann, omero.gateway.MapAnnotationWrapper) ]
+                  if isinstance(ann, omero.gateway.MapAnnotationWrapper)]
 
     try:
         delete = Delete2(targetObjects={'MapAnnotation': mapann_ids})
         handle = conn.c.sf.submit(delete)
         conn.c.waitOnCmd(handle, loops=10, ms=500, failonerror=True,
-                     failontimeout=False, closehandle=False)
+                         failontimeout=False, closehandle=False)
 
     except Exception as ex:
         print("Failed to delete links: {}".format(ex.message))
     return
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-def get_original_file(conn, object_type, object_id, file_ann_id=None):
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    omero_object = conn.getObject("Dataset", int(object_id))
-    if omero_object is None:
-        sys.stderr.write("Error: Dataset does not exist.\n")
-        sys.exit(1)
-    file_ann = None
 
+def get_original_file(omero_object, file_ann_id=None):
+    """Find file linked to object. Option to filter by ID."""
+    file_ann = None
     for ann in omero_object.listAnnotations():
         if isinstance(ann, omero.gateway.FileAnnotationWrapper):
             file_name = ann.getFile().getName()
@@ -106,96 +87,179 @@ def get_original_file(conn, object_type, object_id, file_ann_id=None):
     return file_ann.getFile()._obj
 
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-def populate_metadata(client, conn, script_params):
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    dataType = script_params["Data_Type"]
-    ids      = script_params["IDs"]
+def link_file_ann(conn, object_type, object_id, file_ann_id):
+    """Link File Annotation to the Object, if not already linked."""
+    file_ann = conn.getObject("Annotation", file_ann_id)
+    if file_ann is None:
+        sys.stderr.write("Error: File Annotation not found: %s.\n"
+                         % file_ann_id)
+        sys.exit(1)
+    omero_object = conn.getObject(object_type, object_id)
+    # Check for existing links
+    links = list(conn.getAnnotationLinks(object_type, parent_ids=[object_id],
+                                         ann_ids=[file_ann_id]))
+    if len(links) == 0:
+        omero_object.linkAnnotation(file_ann)
 
-    datasets = list(conn.getObjects(dataType, ids))
-    for ds in datasets:
-        ID = ds.getId()
 
-        # not sure what this is doing
+def get_children_by_name(omero_obj):
+
+    images_by_name = {}
+    wells_by_name = {}
+
+    if omero_obj.OMERO_CLASS == "Dataset":
+        for img in omero_obj.listChildren():
+            img_name = img.getName()
+            if img_name in images_by_name:
+                sys.stderr.write("File names not unique: {}".format(img_name))
+                sys.exit(1)
+            images_by_name[img_name] = img
+    elif omero_obj.OMERO_CLASS == "Plate":
+        for well in omero_obj.listChildren():
+            label = well.getWellPos()
+            wells_by_name[label] = well
+            for ws in well.listChildren():
+                img = ws.getImage()
+                img_name = img.getName()
+                if img_name in images_by_name:
+                    sys.stderr.write(
+                        "File names not unique: {}".format(img_name))
+                    sys.exit(1)
+                images_by_name[img_name] = img
+    else:
+        sys.stderr.write(f'{omero_obj.OMERO_CLASS} objects not supported')
+
+    return images_by_name, wells_by_name
+
+
+def keyval_from_csv(conn, script_params):
+    data_type = script_params["Data_Type"]
+    ids = script_params["IDs"]
+
+    for target_object in conn.getObjects(data_type, ids):
+
+        # file_ann_id is Optional. If not supplied, use first .csv attached
         file_ann_id = None
         if "File_Annotation" in script_params:
-            file_ann_id = long(script_params["File_Annotation"])
-            print("set ann id")
+            file_ann_id = int(script_params["File_Annotation"])
+            link_file_ann(conn, data_type, target_object.id, file_ann_id)
+            print("set ann id", file_ann_id)
 
-        original_file = get_original_file(
-            conn, dataType, ID, file_ann_id)
+        original_file = get_original_file(target_object, file_ann_id)
+        print("Original File", original_file.id.val, original_file.name.val)
         provider = DownloadingOriginalFileProvider(conn)
 
         # read the csv
         file_handle = provider.get_original_file_data(original_file)
-        data =list(csv.reader(file_handle,delimiter=','))
+        data = list(csv.reader(file_handle, delimiter=','))
         file_handle.close()
 
-        # create a dictionary for image_name:id
-        dict_name_id={}
-        for img in ds.listChildren():
-            img_name = img.getName()
-            if( img_name in dict_name_id ):
-                sys.stderr.write("File names not unique: {}".format(img_name))
-                sys.exit(1)
-            dict_name_id[img_name] = int(img.getId())
-
         # keys are in the header row
-        header =data[0]
-        kv_data = header[1:]  # first header is the fimename columns
-        rows    = data[1:]
+        header = data[0]
+        print("header", header)
+
+        # create dictionaries for well/image name:object
+        images_by_name, wells_by_name = get_children_by_name(target_object)
+
+        image_index = header.index("image")
+        well_index = header.index("well")
+        plate_index = header.index("plate")
+        if image_index == -1:
+            # first header is the img-name column, if 'image' not found
+            image_index = 0
+        print("image_index:", image_index, "well_index:", well_index,
+              "plate_index:", plate_index)
+        rows = data[1:]
 
         nimg_updated = 0
-        for row in rows: # loop over images
-            img_name = row[0]
-            if( img_name not in dict_name_id ):
-                print("Can't find filename : {}".format(img_name) )
-            else:
-                img_ID = dict_name_id[img_name]         # look up the ID
-                img    = conn.getObject('Image',img_ID) # get the img
-
-                existing_kv = get_existing_map_annotations( img )
-                updated_kv  = copy.deepcopy(existing_kv)
-                print("Existing kv ")
-                for k,vset in existing_kv.items():
-                    print(type(vset),len(vset))
-                    for v in vset:
-                        print(k,v)
-
-                for i in range(1,len(row)):  # first entry is the filename
-                    key = header[i].strip()
-                    vals = row[i].strip().split(';')
-                    if( len(vals) > 0 ):
-                        for val in vals:
-                            if len(val)>0 : 
-                                if key not in updated_kv: updated_kv[key] = set()
-                                print("adding",key,val)
-                                updated_kv[key].add(val)
-
-                if( existing_kv != updated_kv ):
-                    nimg_updated = nimg_updated + 1
-                    print("The key-values pairs are different")
-                    remove_map_annotations( conn, 'Image', img.getId()  )
-                    map_ann = omero.gateway.MapAnnotationWrapper(conn)
-                    namespace = omero.constants.metadata.NSCLIENTMAPANNOTATION
-                    map_ann.setNs(namespace)
-                    # convert the ordered dict to a list of lists
-                    kv_list=[]
-                    for k,vset in updated_kv.items():
-                        for v in vset:
-                            kv_list.append( [k,v] )
-                    map_ann.setValue(kv_list)
-                    map_ann.save()
-                    img.linkAnnotation(map_ann)
+        # loop over csv rows...
+        for row in rows:
+            # try to find 'image', then 'well', then 'plate'
+            image_name = row[image_index]
+            well_name = None
+            plate_name = None
+            obj = None
+            if len(image_name) > 0:
+                if image_name in images_by_name:
+                    obj = images_by_name[image_name]
+                    print("Annotating Image:", obj.id, image_name)
                 else:
-                    print("No change change in kv's")
+                    print("Image not found:", image_name)
+            if obj is None and well_index > -1 and len(row[well_index]) > 0:
+                well_name = row[well_index]
+                if well_name in wells_by_name:
+                    obj = wells_by_name[well_name]
+                    print("Annotating Well:", obj.id, well_name)
+                else:
+                    print("Well not found:", well_name)
+            if obj is None and plate_index > -1:
+                plate_name = row[plate_index]
+                if plate_name == target_object.name:
+                    obj = target_object
+                    print("Annotating Plate:", obj.id, plate_name)
+            if obj is None:
+                msg = f"Can't find object by image, well or plate name"
+                print(msg)
+                continue
 
-    return "Added {} kv pairs to {}/{} files  ".format(len(header)-1,nimg_updated,len(dict_name_id))
+            cols_to_ignore = [image_index, well_index, plate_index]
+            updated = annotate_object(conn, obj, header, row, cols_to_ignore)
+            if updated:
+                nimg_updated += 1
+
+    return "Added {} kv pairs to {}/{} files  ".format(
+        len(header)-1, nimg_updated, len(images_by_name))
+
+
+def annotate_object(conn, obj, header, row, cols_to_ignore):
+
+    obj_updated = False
+    existing_kv = get_existing_map_annotations(obj)
+    updated_kv = copy.deepcopy(existing_kv)
+    print("Existing kv:")
+    for k, vset in existing_kv.items():
+        for v in vset:
+            print("   ", k, v)
+
+    print("Adding kv:")
+    for i in range(len(row)):
+        if i in cols_to_ignore or i >= len(header):
+            continue
+        key = header[i].strip()
+        vals = row[i].strip().split(';')
+        if len(vals) > 0:
+            for val in vals:
+                if len(val) > 0:
+                    if key not in updated_kv:
+                        updated_kv[key] = set()
+                    print("   ", key, val)
+                    updated_kv[key].add(val)
+
+    if existing_kv != updated_kv:
+        obj_updated = True
+        print("The key-values pairs are different")
+        remove_map_annotations(conn, obj)
+        map_ann = omero.gateway.MapAnnotationWrapper(conn)
+        namespace = omero.constants.metadata.NSCLIENTMAPANNOTATION
+        map_ann.setNs(namespace)
+        # convert the ordered dict to a list of lists
+        kv_list = []
+        for k, vset in updated_kv.items():
+            for v in vset:
+                kv_list.append([k, v])
+        map_ann.setValue(kv_list)
+        map_ann.save()
+        print("Map Annotation created", map_ann.id)
+        obj.linkAnnotation(map_ann)
+    else:
+        print("No change change in kv")
+
+    return obj_updated
 
 
 def run_script():
 
-    data_types = [rstring('Dataset')]
+    data_types = [rstring('Dataset'), rstring('Plate')]
     client = scripts.client(
         'Add_Key_Val_from_csv',
         """
@@ -229,12 +293,10 @@ def run_script():
         # wrap client to use the Blitz Gateway
         conn = BlitzGateway(client_obj=client)
         print("script params")
-        for k,v in script_params.items():
-            print(k,v)
-        message = populate_metadata(client, conn, script_params)
+        for k, v in script_params.items():
+            print(k, v)
+        message = keyval_from_csv(conn, script_params)
         client.setOutput("Message", rstring(message))
-    except:
-        pass
 
     finally:
         client.closeSession()

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -155,11 +155,23 @@ def keyval_from_csv(conn, script_params):
         temp_name = temp_file.name
         with open(temp_name, 'rt', encoding='utf-8-sig') as file_handle:
             try:
-                delimiter = csv.Sniffer().sniff(file_handle.read(1024)).delimiter
-                print("Using delimiter: ", delimiter)
+                delimiter = csv.Sniffer().sniff(file_handle.read(500),",;\t").delimiter
+                print("Using delimiter: ", delimiter,"  after reading 500 characters")
             except Exception:
-                print("Failed to sniff delimiter, using ','")
-                delimiter = ","
+                 pass
+                file_handle.seek(0)
+                try:
+                    delimiter = csv.Sniffer().sniff(file_handle.read(1000),",;\t").delimiter
+                    print("Using delimiter: ", delimiter, "  after reading 1000 characters")
+                except Exception:
+                    pass
+                    file_handle.seek(0)
+                    try:
+                        delimiter = csv.Sniffer().sniff(file_handle.read(2000),";,\t").delimiter
+                        print("Using delimiter: ", delimiter, "  after reading 2000 characters")
+                    except Exception:
+                        print("Failed to sniff delimiter, using ','")
+                        delimiter = ","
             # reset to start and read whole file...
             file_handle.seek(0)
             data = list(csv.reader(file_handle, delimiter=delimiter))

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -151,7 +151,15 @@ def keyval_from_csv(conn, script_params):
 
         # read the csv
         file_handle = provider.get_original_file_data(original_file)
-        data = list(csv.reader(file_handle, delimiter=','))
+        try:
+            delimiter = csv.Sniffer().sniff(file_handle.read(1024)).delimiter
+            print("Using delimiter: ", delimiter)
+        except Exception:
+            print("Failed to sniff delimiter, using ','")
+            delimiter = ","
+        # reset to start and read whole file...
+        file_handle.seek(0)
+        data = list(csv.reader(file_handle, delimiter=delimiter))
         file_handle.close()
 
         # keys are in the header row

--- a/omero/annotation_scripts/KeyVal_to_csv.py
+++ b/omero/annotation_scripts/KeyVal_to_csv.py
@@ -27,39 +27,32 @@ import omero
 from omero.gateway import BlitzGateway
 from omero.rtypes import rstring, rlong
 import omero.scripts as scripts
-from omero.model import PlateI, ScreenI, DatasetI
-from omero.rtypes import *
 from omero.cmd import Delete2
 
 import tempfile
 
-import os,sys
-import csv
-import copy
+import os
 
 from collections import OrderedDict
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-def GetExistingMapAnnotions( obj ):
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+def get_existing_map_annotions(obj):
     ord_dict = OrderedDict()
     for ann in obj.listAnnotations():
-        if( isinstance(ann, omero.gateway.MapAnnotationWrapper) ):
+        if(isinstance(ann, omero.gateway.MapAnnotationWrapper)):
             kvs = ann.getValue()
-            for k,v in kvs:
-                if k not in ord_dict: ord_dict[k] = set()
+            for k, v in kvs:
+                if k not in ord_dict:
+                    ord_dict[k] = set()
                 ord_dict[k].add(v)
     return ord_dict
 
 
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-def attach_csv_file( conn, obj, data ):
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+def attach_csv_file(conn, obj, data):
     ''' writes the data (list of dicts) to a file
     and attaches it to the object
         conn : connection to OMERO (need to annotation creation
-        obj  : the object to attach the file file to 
+        obj  : the object to attach the file file to
         data : the data
     '''
     # create the tmp directory
@@ -69,50 +62,48 @@ def attach_csv_file( conn, obj, data ):
 
     # get the list of  keys and maximum number of occurences
     # A key can appear multiple times, for example multiple dyes can be used
-    key_union=OrderedDict()
-    for img_n,img_kv in data.items():
-        for key, vset  in img_kv.items():
-            key_union[key] = max(key_union.get(key,0),len(vset))
-    all_keys = key_union.keys()
+    key_union = OrderedDict()
+    for img_n, img_kv in data.items():
+        for key, vset in img_kv.items():
+            key_union[key] = max(key_union.get(key, 0), len(vset))
 
     # convience function to write a csv line
-    def to_csv( ll ):
+    def to_csv(ll):
         nl = len(ll)
         fmstr = "{}, "*(nl-1)+"{}\n"
         return fmstr.format(*ll)
 
     # construct the header of the CSV file
     header = ['filename']
-    for key,count in key_union.items():
-        header.extend( [key]*count )      # keys can repeat multiple times
-    tfile.write( to_csv( header ) )
+    for key, count in key_union.items():
+        header.extend([key] * count)      # keys can repeat multiple times
+    tfile.write(to_csv(header))
 
     # write the keys values for each file
-    for filename,kv_dict in data.items():
-        row    = [""]*len(header)   # empty row 
+    for filename, kv_dict in data.items():
+        row = [""] * len(header)   # empty row
         row[0] = filename
-        for key,vset, in kv_dict.items():
-            n0   = header.index(key)     # first occurence of key in header
-            for i,val in enumerate(vset):
-                row[n0+i] = val
-        tfile.write( to_csv( row ) )
+        for key, vset in kv_dict.items():
+            n0 = header.index(key)     # first occurence of key in header
+            for i, val in enumerate(vset):
+                row[n0 + i] = val
+        tfile.write(to_csv(row))
     tfile.close()
 
     name = "{}_metadata_out.csv".format(obj.getName())
     # link it to the object
     ann = conn.createFileAnnfromLocalFile(
         tmp_file, origFilePathAndName=name,
-        ns='MIF_test' )
+        ns='MIF_test')
     ann = obj.linkAnnotation(ann)
 
     # remove the tmp file
     os.remove(tmp_file)
-    os.rmdir (tmp_dir )
+    os.rmdir(tmp_dir)
     return "done"
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 def run_script():
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     data_types = [rstring('Dataset')]
     client = scripts.client(
@@ -149,48 +140,48 @@ def run_script():
 
         dataType = script_params["Data_Type"]
         print(dataType)
-        ids      = script_params["IDs"]
-        datasets = list(conn.getObjects(dataType, ids))    # generator of images or datasets
+        ids = script_params["IDs"]
+        datasets = list(conn.getObjects(dataType, ids))
         print(ids)
         print("datasets:")
-        print( datasets )
+        print(datasets)
         for ds in datasets:
             # name of the file
-            csv_name = "{}_metadata_out.csv".format(ds.getName()) 
+            csv_name = "{}_metadata_out.csv".format(ds.getName())
             print(csv_name)
 
             # remove the csv if it exists
             for ann in ds.listAnnotations():
-                if( isinstance(ann, omero.gateway.FileAnnotationWrapper) ):
-                    if( ann.getFileName() == csv_name ):
+                if(isinstance(ann, omero.gateway.FileAnnotationWrapper)):
+                    if(ann.getFileName() == csv_name):
                         # if the name matches delete it
                         try:
-                            delete = Delete2(targetObjects={'FileAnnotation': [int(ann.getId())]})
+                            delete = Delete2(
+                                targetObjects={'FileAnnotation':
+                                               [ann.getId()]})
                             handle = conn.c.sf.submit(delete)
-                            conn.c.waitOnCmd(handle, loops=10, ms=500, failonerror=True,
-                                         failontimeout=False, closehandle=False)
+                            conn.c.waitOnCmd(
+                                handle, loops=10,
+                                ms=500, failonerror=True,
+                                failontimeout=False, closehandle=False)
                             print("Deleted existing csv")
                         except Exception as ex:
-                            print("Failed to delete existing csv: {}".format(ex.message))
+                            print("Failed to delete existing csv: {}".format(
+                                ex.message))
                 else:
                     print("No exisiting file")
-       
-            #                                 filename         key          multiple vals
-            # assemble the metadata into an OrderedDict of ( OrderedDict of Sets          )
-            file_names = [ img.getName() for img in list(ds.listChildren()) ]
+
+            # assemble the metadata into an OrderedDict
             kv_dict = OrderedDict()
             for img in ds.listChildren():
                 fn = img.getName()
-                kv_dict[fn] = GetExistingMapAnnotions(img)
+                kv_dict[fn] = get_existing_map_annotions(img)
 
             # attach the data
-            mess = attach_csv_file( conn, ds, kv_dict )
+            mess = attach_csv_file(conn, ds, kv_dict)
             print(mess)
-        mess="done" 
+        mess = "done"
         client.setOutput("Message", rstring(mess))
-    
-    except:
-        pass
 
     finally:
         client.closeSession()

--- a/omero/annotation_scripts/KeyVal_to_csv.py
+++ b/omero/annotation_scripts/KeyVal_to_csv.py
@@ -138,10 +138,10 @@ def run_script():
         conn = BlitzGateway(client_obj=client)
         print("connection made")
 
-        dataType = script_params["Data_Type"]
-        print(dataType)
+        data_type = script_params["Data_Type"]
+        print(data_type)
         ids = script_params["IDs"]
-        datasets = list(conn.getObjects(dataType, ids))
+        datasets = list(conn.getObjects(data_type, ids))
         print(ids)
         print("datasets:")
         print(datasets)

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -305,7 +305,8 @@ def process_image(conn, image_id, parameter_map):
                             if t in xy_by_time:
                                 x = xy_by_time[t]['x']
                                 y = xy_by_time[t]['y']
-                            tile = (max(0, min(x, x_max)), max(0, min(y, y_max)), w, h)
+                            tile = (max(0, min(x, x_max)),
+                                    max(0, min(y, y_max)), w, h)
                             zct_tile_list.append((z, c, t, tile))
 
                 def tile_gen():


### PR DESCRIPTION
This PR contains all commits from https://github.com/mpievolbio-scicomp/omero-scripts/pull/1.

To test: a CSV of this format should behave according to the comment after each row:
```
plate           well    image               Cell line
Index.idx.xml                               S2R+        # add KV to plate
Index.idx.xml   B2                          S2R+        # add KV to well only
Index.idx.xml   B2      Well 1 Field 1      S2R+        # add KV to image only
Index.idx.xml           Well 1 Field 2      S2R+        # add KV to image only
```

A couple of additional points addressed in this PR:

- Improved warning if any Well or Image names don't match (see
https://github.com/mpievolbio-scicomp/omero-scripts/pull/1#pullrequestreview-853682915)
This is now shown in response message:

<img width="409" alt="Screenshot 2022-01-23 at 22 44 19" src="https://user-images.githubusercontent.com/900055/150701090-1fec764f-7c8e-4d43-8f88-780435a964a9.png">

 - Handling of various CSV delimiters by sniffing as suggested by @JensWendt (see https://github.com/mpievolbio-scicomp/omero-scripts/pull/1#issuecomment-1016426161)

cc @abhamacher Does this look OK?
If you could give this a final test and 👍 if looking good, that would be great, thanks.

To test (OME)
==========

Using Plate at https://merge-ci.openmicroscopy.org/web/webclient/?show=plate-16105 (user-3).
This has a test `.csv` file attached, using the format above. Sample of it pasted below. The `target` column says what should be annotated by each row.
Download, inspect and edit the file, then use to run the `annotations_scripts/KeyVal_from_csv.py` script.
Rows which have an `image` name will annotate that Image (Well column is ignored)
Rows without an `image` will annotate the Well.
NB: Can use the `Remove_KeyVal.py` script to remove all Well and Image annotations on the Plate if needed.

```
plate,well,image,target,Time,cell_count,Mitotic fraction,
to-plate_1,A1,A1 Field 1,Image A1 Field 1,10,1,0.1,
to-plate_1,A1,A1 Field 2,Image A1 Field 2,11,2,0.11,
to-plate_1,A2,A2 Field 1,Image A2 Field 1,20,3,0.2,
to-plate_1,A2,,Well A2,21,4,0.21,
to-plate_1,A3,A3 Field 1,Image A3 Field 1,30,5,0.3,
to-plate_1,A4,,Well A4,40,6,0.4,
to-plate_1,A5,,Well A5,50,7,0.5,
to-plate_1,A6,A6 Field 1,A6 Field 1,60,8,0.6,
to-plate_1,B10,B1 Field 1,Image B1 Field 1 (Well ignored),110,9,0.1,
to-plate_1,B20,B2 Field 1,Image B2 Field 1 (Well ignored),120,10,0.2,
to-plate_1,,,Plate (No Well or Image),130,11,0.3,
invalid,B4,B4 Field 1,NONE (plate name invalid),140,12,0.4,
to-plate_1,B5,B5 Field 1,Image B5 Field 1,160,13,0.5,
to-plate_1,B6,B6 Field 1,Image B6 Field 1,160,14,0.6,
```