### PR TITLE
Images from ROIs track xy

### DIFF
--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -453,7 +453,7 @@ def run_script():
         'Images_From_ROIs.py',
         """Crop an Image using Rectangular ROIs, to create new Images.
 ROIs that extend across Z and T will crop according to the Z and T limits
-of each ROI. If NO Z set, use all Z planes. If NO T set, use all T planes.
+of each ROI.
 If you choose to 'make an image stack' from all the ROIs, the script \
 will create a single new Z-stack image with a single plane from each ROI.
 ROIs that are 'Big', typically over 3k x 3k pixels will create 'tiled'

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -167,7 +167,8 @@ def get_rectangles(conn, image_id):
             t_end = max(t_indexes) if t_indexes else None
             z_start = min(z_indexes) if z_indexes else None
             z_end = max(z_indexes) if z_indexes else None
-            rois.append((x, y, width, height, z_start, z_end, t_start, t_end, xy_by_time))
+            rois.append((x, y, width, height, z_start, z_end,
+                         t_start, t_end, xy_by_time))
 
     return rois
 

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -49,7 +49,7 @@ def create_image_from_tiles(conn, source, image_name, description,
 
     pixels_service = conn.getPixelsService()
     query_service = conn.getQueryService()
-    xbox, ybox, wbox, hbox, z1box, z2box, t1box, t2box = box
+    xbox, ybox, wbox, hbox, z1box, z2box, t1box, t2box, xy_by_time = box
     size_x = wbox
     size_y = hbox
     size_z = source.getSizeZ()
@@ -137,9 +137,11 @@ def get_rectangles(conn, image_id):
     result = roi_service.findByImage(image_id, None)
 
     for roi in result.rois:
-        x = None
+        width = None
         z_indexes = []
         t_indexes = []
+        # note x and y for every T, to track moving object
+        xy_by_time = {}
         for shape in roi.copyShapes():
             if type(shape) == omero.model.RectangleI:
                 # check t range and z range for every rectangle
@@ -152,18 +154,20 @@ def get_rectangles(conn, image_id):
                 if the_z is not None:
                     z_indexes.append(the_z)
 
-                if x is None:   # get x, y, width, height for first rect only
-                    x = int(shape.getX().getValue())
-                    y = int(shape.getY().getValue())
+                if width is None:   # get width, height for first rect only
                     width = int(shape.getWidth().getValue())
                     height = int(shape.getHeight().getValue())
+                x = int(shape.getX().getValue())
+                y = int(shape.getY().getValue())
+                if the_t is not None:
+                    xy_by_time[the_t] = {'x': x, 'y': y}
         # if we have found any rectangles at all for this ROI...
-        if x is not None:
+        if width is not None:
             t_start = min(t_indexes) if t_indexes else None
             t_end = max(t_indexes) if t_indexes else None
             z_start = min(z_indexes) if z_indexes else None
             z_end = max(z_indexes) if z_indexes else None
-            rois.append((x, y, width, height, z_start, z_end, t_start, t_end))
+            rois.append((x, y, width, height, z_start, z_end, t_start, t_end, xy_by_time))
 
     return rois
 
@@ -201,8 +205,8 @@ def process_image(conn, image_id, parameter_map):
     img_w = image.getSizeX()
     img_h = image.getSizeY()
 
-    for index, r in enumerate(rois):
-        x, y, w, h, z1, z2, t1, t2 = r
+    for index, roi in enumerate(rois):
+        x, y, w, h, z1, z2, t1, t2, xy_by_time = roi
         # Bounding box
         x_max = max(x, 0)
         y_max = max(y, 0)
@@ -221,22 +225,22 @@ def process_image(conn, image_id, parameter_map):
     if image_stack:
         # use width and height from first roi to make sure that all are the
         # same.
-        x, y, width, height, z1, z2, t1, t2 = rois[0]
+        x, y, width, height, z1, z2, t1, t2, xy_by_time = rois[0]
 
         def tile_gen():
             # list a tile from each ROI and create a generator of 2D planes
             zct_tile_list = []
             # assume single channel image Electron Microscopy use case
             c = 0
-            for r in rois:
-                x, y, w, h, z1, z2, t1, t2 = r
+            for roi in rois:
+                x, y, w, h, z1, z2, t1, t2, xy_by_time = roi
                 tile = (x, y, width, height)
                 the_z = z1 if z1 is not None else 0
                 the_t = t1 if t1 is not None else 0
                 zct_tile_list.append((the_z, c, the_t, tile))
             print('image_stack zct_tile_list:', zct_tile_list)
-            for t in pixels.getTiles(zct_tile_list):
-                yield t
+            for tile in pixels.getTiles(zct_tile_list):
+                yield tile
 
         if 'Container_Name' in parameter_map:
             new_image_name = "%s_%s" % (os.path.basename(image_name),
@@ -269,9 +273,9 @@ def process_image(conn, image_id, parameter_map):
         big_image_size = conn.getMaxPlaneSize()
         big_image_pixel_count = big_image_size[0] * big_image_size[1]
 
-        for index, r in enumerate(rois):
+        for index, roi in enumerate(rois):
             new_name = "%s_%0d" % (image_name, index)
-            x, y, w, h, z1, z2, t1, t2 = r
+            x, y, w, h, z1, z2, t1, t2, xy_by_time = roi
 
             if z1 is None:
                 z1 = 0
@@ -292,10 +296,13 @@ def process_image(conn, image_id, parameter_map):
                 size_t = t2-t1 + 1
                 size_c = image.getSizeC()
                 zct_tile_list = []
-                tile = (x, y, w, h)
                 for z in range(z1, z2+1):
                     for c in range(size_c):
                         for t in range(t1, t2+1):
+                            if t in xy_by_time:
+                                x = xy_by_time[t]['x']
+                                y = xy_by_time[t]['y']
+                            tile = (x, y, w, h)
                             zct_tile_list.append((z, c, t, tile))
 
                 def tile_gen():
@@ -309,7 +316,7 @@ def process_image(conn, image_id, parameter_map):
             else:
                 tile_size = parameter_map['Tile_Size']
                 new_img = create_image_from_tiles(conn, image, new_name,
-                                                  description, r, tile_size)
+                                                  description, roi, tile_size)
 
             images.append(new_img)
             iids.append(new_img.getId())

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -451,9 +451,9 @@ def run_script():
 
     client = scripts.client(
         'Images_From_ROIs.py',
-        """Crop an Image using Rectangular ROIs, to create new Images.
-ROIs that extend across Z and T will crop according to the Z and T limits
-of each ROI.
+        """Crop an Image using Rectangular ROIs, to create a new Image
+for each ROI. ROIs that extend across Z and T will crop according to
+the Z and T limits of each ROI.
 If you choose to 'make an image stack' from all the ROIs, the script \
 will create a single new Z-stack image with a single plane from each ROI.
 ROIs that are 'Big', typically over 3k x 3k pixels will create 'tiled'

--- a/omero/util_scripts/Images_From_ROIs.py
+++ b/omero/util_scripts/Images_From_ROIs.py
@@ -277,6 +277,8 @@ def process_image(conn, image_id, parameter_map):
         for index, roi in enumerate(rois):
             new_name = "%s_%0d" % (image_name, index)
             x, y, w, h, z1, z2, t1, t2, xy_by_time = roi
+            x_max = img_w - w
+            y_max = img_h - h
 
             if z1 is None:
                 z1 = 0
@@ -303,7 +305,7 @@ def process_image(conn, image_id, parameter_map):
                             if t in xy_by_time:
                                 x = xy_by_time[t]['x']
                                 y = xy_by_time[t]['y']
-                            tile = (x, y, w, h)
+                            tile = (max(0, min(x, x_max)), max(0, min(y, y_max)), w, h)
                             zct_tile_list.append((z, c, t, tile))
 
                 def tile_gen():


### PR DESCRIPTION
From user request to create a Movie from an ROI when the ROI moves in x and y over time.

This PR improves the `Images_from_ROIs.py` script so that the X and Y of the rectangle at each time point are used to crop the image.

To test:
 - Draw a Rectangle in Insight, then right-click and "propagate" it through Time (drag the square across Time axis to cover all the T-indices you wish to).
 
![Screenshot 2022-02-03 at 20 09 49](https://user-images.githubusercontent.com/900055/152421044-05bfdecf-c6ac-4bbe-8c25-f6dca135cabf.png)

 - Close that dialog, then update the X and Y position of the Rectangle at each time point (so as to track a moving object)
 - Save the ROI (with multiple Rectangles within it). You can do this for multiple ROIs on the Images.
 - Return to the main Insight window, select the Image and click on the Run-script button (green arrow with cogs) and find the `Images_From_ROIs` script (your hierarchy might look a bit different)

![Screenshot 2022-02-02 at 08 49 38](https://user-images.githubusercontent.com/900055/152422024-7a2bd2ec-0fc2-4193-92d1-9f1b8f1e73dc.png)

 - You can run this script with the default values.
 - A new Image should be created for (each) ROI and the crop at each time-point should respect the position of the Rectangle at that time-point. These will be in a new Dataset (called `from_ROIs` by default).

 - NB: to export each of these Images as a Movie, use the `Make Movie` functionality for each one in turn.

cc @pwalczysko 