### PR TITLE
Adding Support for different CSV Encodings in Import_Scripts/Populate_Metadata.py

### DIFF
--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -134,10 +134,10 @@ def populate_metadata(client, conn, script_params):
     object_ids = script_params["IDs"]
     object_id = object_ids[0]
     data_type = script_params["Data_Type"]
-    
-    if EncSup: #Only get from user if support for encoding is there
+
+    if EncSup:  # Only get from user if support for encoding is there
         encoding = script_params["CSV Encoding"]
-    
+
     if data_type == "Image":
         try:
             from omero_metadata.populate import ImageWrapper    # noqa: F401
@@ -154,8 +154,8 @@ def populate_metadata(client, conn, script_params):
         data_for_preprocessing = provider.get_original_file_data(original_file, encoding=encoding)
     except UnicodeDecodeError as e:
         raise ValueError("The CSV file provided could not be decoded using "
-              "the specified encoding. Please check the encoding "
-              "and contents of the file!") from e
+                         "the specified encoding. Please check the encoding "
+                         "and contents of the file!") from e
 
     temp_name = data_for_preprocessing.name
     # 5.9.1 returns NamedTempFile where name is a string.
@@ -203,7 +203,7 @@ def run_script():
 
     # Add Encoding field if support for encodings
     if EncSup:
-        fields.append( scripts.String(
+        fields.append(scripts.String(
             "CSV Encoding", grouping="4",
             description="""Encoding of the CSV File provided. Can depend on
             your system locale as well as the program used to generate the

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -131,7 +131,7 @@ def populate_metadata(client, conn, script_params):
     object_ids = script_params["IDs"]
     object_id = object_ids[0]
     data_type = script_params["Data_Type"]
-    encoding = script_params["CSV Encoding"]
+    if encSup: encoding = script_params["CSV Encoding"]
     if data_type == "Image":
         try:
             from omero_metadata.populate import ImageWrapper    # noqa: F401

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -152,7 +152,7 @@ def populate_metadata(client, conn, script_params):
     provider = DownloadingOriginalFileProvider(conn)
     try:
         data_for_preprocessing = provider.get_original_file_data(original_file, encoding=encoding)
-    except UnicodeDecodeError as e:
+    except ValueError as e:
         raise ValueError("The CSV file provided could not be decoded using "
                          "the specified encoding. Please check the encoding "
                          "and contents of the file!") from e

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -107,7 +107,7 @@ def populate_metadata(client, conn, script_params):
     object_ids = script_params["IDs"]
     object_id = object_ids[0]
     data_type = script_params["Data_Type"]
-
+    encoding = script_params["CSV Encoding"]
     if data_type == "Image":
         try:
             from omero_metadata.populate import ImageWrapper    # noqa: F401
@@ -120,7 +120,7 @@ def populate_metadata(client, conn, script_params):
     original_file = get_original_file(
         conn, data_type, object_id, file_ann_id)
     provider = DownloadingOriginalFileProvider(conn)
-    data_for_preprocessing = provider.get_original_file_data(original_file)
+    data_for_preprocessing = provider.get_original_file_data(original_file, encoding=encoding)
     temp_name = data_for_preprocessing.name
     # 5.9.1 returns NamedTempFile where name is a string.
     if isinstance(temp_name, int):
@@ -172,6 +172,13 @@ def run_script():
             "File_Annotation", grouping="3",
             description="File Annotation ID containing metadata to populate. "
             "Note this is not the same as the File ID."),
+        
+        scripts.String(
+            "CSV Encoding", grouping="4",
+            description="""Encoding of the CSV File provided. Can depend on your system locale 
+            as well as the program used to generate the CSV File. E.g. Excel defaults to machine specific
+            ANSI encoding during export to CSV (i.e. cp1252 on US machines, iso-8859-1 on german machines ...).""",
+            default="utf-8"),
 
         authors=["Emil Rozbicki", "OME Team"],
         institutions=["Glencoe Software Inc."],

--- a/omero/import_scripts/Populate_Metadata.py
+++ b/omero/import_scripts/Populate_Metadata.py
@@ -31,6 +31,7 @@ import omero.model
 import sys
 
 from omero.util.populate_roi import DownloadingOriginalFileProvider
+from omero.util.populate_roi import DecodingError
 
 try:
     # Hopefully this will import
@@ -120,7 +121,12 @@ def populate_metadata(client, conn, script_params):
     original_file = get_original_file(
         conn, data_type, object_id, file_ann_id)
     provider = DownloadingOriginalFileProvider(conn)
-    data_for_preprocessing = provider.get_original_file_data(original_file, encoding=encoding)
+    try:
+        data_for_preprocessing = provider.get_original_file_data(original_file, encoding=encoding)
+    except DecodingError as e:
+        e.add_note("The CSV file provided could not be decoded using the specified encoding. Please check the encoding and contents of the file!")
+        raise
+        
     temp_name = data_for_preprocessing.name
     # 5.9.1 returns NamedTempFile where name is a string.
     if isinstance(temp_name, int):

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -130,31 +130,33 @@ class TestImportScripts(ScriptTest):
         assert sid > 0
         import encodings
         import os
-        import os
-        def encodinglist():
-            r=[]
-            for i in os.listdir(os.path.split(__import__("encodings").__file__)[0]):
+        from omero.util.populate_roi import DownloadingOriginalFileProvider
+        
+        # Skip test if the omero-py version does not yet provide support for the encodings
+        if "encoding" in DownloadingOriginalFileProvider.get_original_file_data.__code__.co_varnames:
+            print("Skipping test of populate_metadata.py for encodings as omero-py version does not support it!")
+            return
+        
+        AvailEncodings=[]
+        for i in os.listdir(os.path.split(__import__("encodings").__file__)[0]):
             name=os.path.splitext(i)[0]
             try:
                 "".encode(name)
             except:
                 pass
             else:
-                r.append(name.replace("_","-"))
-            return r
-        
-
-        encodings = encodinglist()
+                AvailEncodings.append(name.replace("_","-"))
+            
         client, user = self.new_client_and_user()
         conn = BlitzGateway(client_obj=client)
         update_service = client.getSession().getUpdateService()
         
-        for enc in encodings:
+        for enc in AvailEncodings:
             plates = self.import_plates(client, plate_cols=3, plate_rows=1)
             plate = plates[0]
             name = plate.name.val
             screen = omero.model.ScreenI()
-            screen.name = omero.rtypes.rstring("test_for_%s" % (enc)")
+            screen.name = omero.rtypes.rstring("test_for_%s" % (enc))
             spl = omero.model.ScreenPlateLinkI()
             spl.setParent(screen)
             spl.setChild(plate)

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -165,12 +165,15 @@ class TestImportScripts(ScriptTest):
             assert screen_id > 0
             assert spl.getChild().id.val == plate.id.val
             cvs_file = create_path("test_cp1252", ".csv")
-            # create a file annotation
-            with open(cvs_file.abspath(), 'wb+') as f:
-                f.write("Well, Plate, Well Type, Facility-Salt-Batch-ID, Comment,\n".encode(enc))
-                f.write(("A01, %s, Treatment, FOOL10041-101-2, TestString containing greek µ\n" % name).encode(enc))
-                f.write(("A02, %s, Control, FOOL10041-101-2, TestString containing symbol ±\n" % name).encode(enc))
-                f.write(("A03, %s, Treatment, FOOL10041-101-2,TestString containing special character §\n" % name).encode(enc))
+            # create a file annotation. 
+            try:
+                with open(cvs_file.abspath(), 'wb+') as f:
+                    f.write("Well, Plate, Well Type, Facility-Salt-Batch-ID, Comment,\n".encode(enc))
+                    f.write(("A01, %s, Treatment, FOOL10041-101-2, TestString containing greek µ\n" % name).encode(enc))
+                    f.write(("A02, %s, Control, FOOL10041-101-2, TestString containing symbol ±\n" % name).encode(enc))
+                    f.write(("A03, %s, Treatment, FOOL10041-101-2,TestString containing special character §\n" % name).encode(enc))
+            except UnicodeError:  #Skip if test strings are not supported
+                next
             fa = conn.createFileAnnfromLocalFile(cvs_file, mimetype="text/csv")
             assert fa is not None
             assert fa.id > 0

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -130,13 +130,13 @@ class TestImportScripts(ScriptTest):
         assert sid > 0
         import os
         from omero.util.populate_roi import DownloadingOriginalFileProvider
-        
+
         # Skip test if the omero-py version does not support encodings
         if "encoding" in DownloadingOriginalFileProvider.get_original_file_data.__code__.co_varnames:
             print("Skipping test of populate_metadata.py for encodings"
                   "as omero-py version does not support it!")
             return
-        
+
         AvailEncodings = []
         for i in os.listdir(os.path.split(__import__("encodings").__file__)[0]):
             name = os.path.splitext(i)[0]
@@ -146,11 +146,11 @@ class TestImportScripts(ScriptTest):
                 pass
             else:
                 AvailEncodings.append(name.replace("_", "-"))
-            
+
         client, user = self.new_client_and_user()
         conn = BlitzGateway(client_obj=client)
         update_service = client.getSession().getUpdateService()
-        
+
         for enc in AvailEncodings:
             plates = self.import_plates(client, plate_cols=3, plate_rows=1)
             plate = plates[0]
@@ -165,14 +165,14 @@ class TestImportScripts(ScriptTest):
             assert screen_id > 0
             assert spl.getChild().id.val == plate.id.val
             cvs_file = create_path("test_cp1252", ".csv")
-            # create a file annotation. 
+            # create a file annotation.
             try:
                 with open(cvs_file.abspath(), 'wb+') as f:
                     f.write("Well, Plate, Well Type, Facility-Salt-Batch-ID, Comment,\n".encode(enc))
                     f.write(("A01, %s, Treatment, FOOL10041-101-2, TestString containing greek µ\n" % name).encode(enc))
                     f.write(("A02, %s, Control, FOOL10041-101-2, TestString containing symbol ±\n" % name).encode(enc))
                     f.write(("A03, %s, Treatment, FOOL10041-101-2,TestString containing special character §\n" % name).encode(enc))
-            except UnicodeError:  #Skip if test strings are not supported
+            except UnicodeError:  # Skip if test strings are not supported
                 next
             fa = conn.createFileAnnfromLocalFile(cvs_file, mimetype="text/csv")
             assert fa is not None
@@ -185,7 +185,7 @@ class TestImportScripts(ScriptTest):
             # run the script
             screen_ids = []
             screen_ids.append(spl.getParent().id)
-
+            
             args = {
                 "Data_Type": omero.rtypes.rstring("Screen"),
                 "IDs": omero.rtypes.rlist(screen_ids),

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -185,7 +185,7 @@ class TestImportScripts(ScriptTest):
             # run the script
             screen_ids = []
             screen_ids.append(spl.getParent().id)
-            
+
             args = {
                 "Data_Type": omero.rtypes.rstring("Screen"),
                 "IDs": omero.rtypes.rlist(screen_ids),

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -124,3 +124,107 @@ class TestImportScripts(ScriptTest):
         assert message is not None
         assert message.getValue().startswith('Table data populated')
         conn.close()
+
+    def test_populate_metadata_for_cp1252(self):
+        sid = super(TestImportScripts, self).get_script(populate_metadata)
+        assert sid > 0
+
+        client, user = self.new_client_and_user()
+        update_service = client.getSession().getUpdateService()
+        plates = self.import_plates(client, plate_cols=3, plate_rows=1)
+        plate = plates[0]
+        name = plate.name.val
+        screen = omero.model.ScreenI()
+        screen.name = omero.rtypes.rstring("test_for_cp1252")
+        spl = omero.model.ScreenPlateLinkI()
+        spl.setParent(screen)
+        spl.setChild(plate)
+        spl = update_service.saveAndReturnObject(spl)
+        screen_id = spl.getParent().id.val
+        assert screen_id > 0
+        assert spl.getChild().id.val == plate.id.val
+
+        cvs_file = create_path("test_cp1252", ".csv")
+
+        # create a file annotation
+        with open(cvs_file.abspath(), 'wb+') as f:
+            f.write("Well,Plate, Well Type, Facility-Salt-Batch-ID\n".encode("cp1252"))
+            f.write(("A01,%s,Treatment,FOOL10041-101-2\n" % name).encode("cp1252"))
+            f.write(("A02,%s,Control,\n" % name).encode("cp1252"))
+            f.write(("A03,%s,Treatment,FOOL10041-101-2\n" % name).encode("cp1252"))
+
+        conn = BlitzGateway(client_obj=client)
+        fa = conn.createFileAnnfromLocalFile(cvs_file, mimetype="text/csv")
+        assert fa is not None
+        assert fa.id > 0
+        link = omero.model.ScreenAnnotationLinkI()
+        link.setParent(omero.model.ScreenI(screen_id, False))
+        link.setChild(omero.model.FileAnnotationI(fa.id, False))
+        link = update_service.saveAndReturnObject(link)
+        assert link.id.val > 0
+        # run the script
+        screen_ids = []
+        screen_ids.append(spl.getParent().id)
+
+        args = {
+            "Data_Type": omero.rtypes.rstring("Screen"),
+            "IDs": omero.rtypes.rlist(screen_ids),
+            "File_Annotation": omero.rtypes.rstring(str(fa.id)),
+            "CSV Encoding": omero.rtypes.rstring(str("cp1252"))
+        }
+        message = run_script(client, sid, args, "Message")
+        assert message is not None
+        assert message.getValue().startswith('Table data populated')
+        conn.close()
+
+    def test_populate_metadata_for_iso8859(self):
+        sid = super(TestImportScripts, self).get_script(populate_metadata)
+        assert sid > 0
+
+        client, user = self.new_client_and_user()
+        update_service = client.getSession().getUpdateService()
+        plates = self.import_plates(client, plate_cols=3, plate_rows=1)
+        plate = plates[0]
+        name = plate.name.val
+        screen = omero.model.ScreenI()
+        screen.name = omero.rtypes.rstring("test_for_iso8859")
+        spl = omero.model.ScreenPlateLinkI()
+        spl.setParent(screen)
+        spl.setChild(plate)
+        spl = update_service.saveAndReturnObject(spl)
+        screen_id = spl.getParent().id.val
+        assert screen_id > 0
+        assert spl.getChild().id.val == plate.id.val
+
+        cvs_file = create_path("test_iso8859", ".csv")
+
+        # create a file annotation
+        with open(cvs_file.abspath(), 'wb+') as f:
+            f.write("Well,Plate, Well Type, Facility-Salt-Batch-ID\n".encode("iso-8859-1"))
+            f.write(("A01,%s,Treatment,FOOL10041-101-2\n" % name).encode("iso-8859-1"))
+            f.write(("A02,%s,Control,\n" % name).encode("iso-8859-1"))
+            f.write(("A03,%s,Treatment,FOOL10041-101-2\n" % name).encode("iso-8859-1"))
+
+        conn = BlitzGateway(client_obj=client)
+        fa = conn.createFileAnnfromLocalFile(cvs_file, mimetype="text/csv")
+        assert fa is not None
+        assert fa.id > 0
+        link = omero.model.ScreenAnnotationLinkI()
+        link.setParent(omero.model.ScreenI(screen_id, False))
+        link.setChild(omero.model.FileAnnotationI(fa.id, False))
+        link = update_service.saveAndReturnObject(link)
+        assert link.id.val > 0
+        # run the script
+        screen_ids = []
+        screen_ids.append(spl.getParent().id)
+
+        args = {
+            "Data_Type": omero.rtypes.rstring("Screen"),
+            "IDs": omero.rtypes.rlist(screen_ids),
+            "File_Annotation": omero.rtypes.rstring(str(fa.id)),
+            "CSV Encoding": omero.rtypes.rstring(str("iso-8859-1"))
+        }
+        message = run_script(client, sid, args, "Message")
+        assert message is not None
+        assert message.getValue().startswith('Table data populated')
+        conn.close()

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -128,24 +128,24 @@ class TestImportScripts(ScriptTest):
     def test_populate_metadata_for_encodings(self):
         sid = super(TestImportScripts, self).get_script(populate_metadata)
         assert sid > 0
-        import encodings
         import os
         from omero.util.populate_roi import DownloadingOriginalFileProvider
         
-        # Skip test if the omero-py version does not yet provide support for the encodings
+        # Skip test if the omero-py version does not support encodings
         if "encoding" in DownloadingOriginalFileProvider.get_original_file_data.__code__.co_varnames:
-            print("Skipping test of populate_metadata.py for encodings as omero-py version does not support it!")
+            print("Skipping test of populate_metadata.py for encodings"
+                  "as omero-py version does not support it!")
             return
         
-        AvailEncodings=[]
+        AvailEncodings = []
         for i in os.listdir(os.path.split(__import__("encodings").__file__)[0]):
-            name=os.path.splitext(i)[0]
+            name = os.path.splitext(i)[0]
             try:
                 "".encode(name)
             except:
                 pass
             else:
-                AvailEncodings.append(name.replace("_","-"))
+                AvailEncodings.append(name.replace("_", "-"))
             
         client, user = self.new_client_and_user()
         conn = BlitzGateway(client_obj=client)
@@ -167,10 +167,10 @@ class TestImportScripts(ScriptTest):
             cvs_file = create_path("test_cp1252", ".csv")
             # create a file annotation
             with open(cvs_file.abspath(), 'wb+') as f:
-                f.write("Well,Plate, Well Type, Facility-Salt-Batch-ID,Comment,\n".encode(enc))
-                f.write(("A01,%s,Treatment,FOOL10041-101-2,TestString containing greek µ\n" % name).encode(enc))
-                f.write(("A02,%s,Control,TestString containing symbol ±\n" % name).encode(enc))
-                f.write(("A03,%s,Treatment,FOOL10041-101-2,TestString containing special character §\n" % name).encode(enc))
+                f.write("Well, Plate, Well Type, Facility-Salt-Batch-ID, Comment,\n".encode(enc))
+                f.write(("A01, %s, Treatment, FOOL10041-101-2, TestString containing greek µ\n" % name).encode(enc))
+                f.write(("A02, %s, Control, FOOL10041-101-2, TestString containing symbol ±\n" % name).encode(enc))
+                f.write(("A03, %s, Treatment, FOOL10041-101-2,TestString containing special character §\n" % name).encode(enc))
             fa = conn.createFileAnnfromLocalFile(cvs_file, mimetype="text/csv")
             assert fa is not None
             assert fa.id > 0

--- a/test/integration/test_import_scripts.py
+++ b/test/integration/test_import_scripts.py
@@ -189,7 +189,11 @@ class TestImportScripts(ScriptTest):
                 "File_Annotation": omero.rtypes.rstring(str(fa.id)),
                 "CSV Encoding": omero.rtypes.rstring(str(enc))
             }
-            message = run_script(client, sid, args, "Message")
-            assert message is not None
-            assert message.getValue().startswith('Table data populated') or message.getValue.startswith('The CSV file provided could not be decoded')
+            message = None
+            try:
+                message = run_script(client, sid, args, "Message")
+                assert message is not None
+                assert message.getValue().startswith('Table data populated')
+            except ValueError as e:
+                assert str(e).startswith('The CSV file provided could')
         conn.close()


### PR DESCRIPTION
This draft will add support for csv encodings differing from utf-8 to populate_metadata.py.
This is relevant e.g. when using the [Populate_Metadata.py](https://github.com/ome/omero-scripts/blob/14c830099efe1f0d6b32a2b3914febd8ddcd89ea/omero/import_scripts/Populate_Metadata.py) script distributed with OMERO, when using a CSV File exported from Excel with default settings, which are cp1252 for US and iso-8859-1 for EU system locales.

It requires merging of https://github.com/ome/omero-py/pull/325 in omero-py, to add support for this in the imported `omero.utils.populate_roi` script. If this gets merged, support for different encoding can happen by simply adding a new string input field to the `script_params`, that will contain the file encoding and default to utf-8 (i.e. legacy behaviour).

Tests for `cp1252` and `iso-8859-1`, the default encodings for US and EU Excel CSV exports have been added as well.


// Julian