### PR TITLE
Fixed error message output for Batch_Image_Export

### DIFF
--- a/omero/export_scripts/Batch_Image_Export.py
+++ b/omero/export_scripts/Batch_Image_Export.py
@@ -283,7 +283,7 @@ def batch_image_export(conn, script_params):
 
     if (not split_cs) and (not merged_cs):
         log("Not chosen to save Individual Channels OR Merged Image")
-        return
+        return None, "Not chosen to save Individual Channels OR Merged Image"
 
     # check if we have these params
     channel_names = []


### PR DESCRIPTION

The script gives two choices to the user; to Export Individual Channels OR to Export Meged Image. The user might fail to select either of the options.

<img width="318" alt="Screenshot 2022-08-08 at 4 17 57 pm" src="https://user-images.githubusercontent.com/86613209/183452897-552fea47-e561-4f39-9edb-dbc6a70dcb3b.png">

This PR fixed the output message to alert the user that they need to chose either of the option.

#### Without PR
Script fails to exit correctly with `TypeError`.
```
Traceback (most recent call last):
  File "./script", line 625, in <module>
    run_script()
  File "./script", line 609, in run_script
    file_annotation, message = batch_image_export(conn, script_params)
TypeError: 'NoneType' object is not iterable
```

#### With PR
The output message displays "Not chosen to save Individual Channels OR Merged Image" and exits correctly.
<img width="397" alt="image" src="https://user-images.githubusercontent.com/86613209/183452245-4936f26d-e2dc-47fd-81a8-fdb3b56b0905.png">
