### PR TITLE
Add top-level Git mailmap to normalize commit author variants

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,24 @@
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk>
+Anna Hamacher <anna.hamacher@hhu.de> <61734239+abhamacher@users.noreply.github.com>
+Carsten Fortmann-Grote <carsten.fortmann-grote@evolbio.mpg.de> <grotec@evolbio.mpg.de>
+Carlos Neves <carlos@glencoesoftware.com> <staff@glencoesoftware.com>
+Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
+Christian Evenhuis <christian.evenhuis@gmail.com> <evenhuis@uts.edu.au>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-81a1db45b4a6>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <dzmacdonald@05709c45-44f0-0310-885b-81a1db45b4a6>
+Emil Rozbicki <emil@glencoesoftware.com> <emilroz@gmail.com>
+Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
+Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@05709c45-44f0-0310-885b-81a1db45b4a6>
+Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
+Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
+Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
+Josh Moore <josh@openmicroscopy.org> <jmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
+Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
+Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
+Petr Walczysko <p.walczysko@dundee.ac.uk>
+Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
+Will Moore <w.moore@dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> <wmoore@05709c45-44f0-0310-885b-81a1db45b4a6>

--- a/.mailmap
+++ b/.mailmap
@@ -9,7 +9,7 @@ Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-8
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <dzmacdonald@05709c45-44f0-0310-885b-81a1db45b4a6>
 Emil Rozbicki <emil@glencoesoftware.com> <emilroz@gmail.com>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
-Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> jburel <j.burel@dundee.ac.uk>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@05709c45-44f0-0310-885b-81a1db45b4a6>
 Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
 Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
@@ -17,8 +17,8 @@ Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
 Josh Moore <josh@openmicroscopy.org> <jmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
 Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
 Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
-Petr Walczysko <p.walczysko@dundee.ac.uk>
+Petr Walczysko <p.walczysko@dundee.ac.uk> pwalczysko <p.walczysko@dundee.ac.uk>
 Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
-Will Moore <w.moore@dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> William Moore <w.moore@dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <wmoore@05709c45-44f0-0310-885b-81a1db45b4a6>


### PR DESCRIPTION
This PR adds a top-level mapping file allowing to normalize commits from the same contributor and associate all commits to a canonical "First Name Last Name <email>" author line.

The following rules are used for the construction of the .mailmap file:

- for all contributors who are employees of the University or Dundee, Glencoe Software, the `@dundee.ac.uk`,  or `@glencoesoftware.com` email address is used as the canonical email address
- for all contributors with an executed CLA, the real name and email address sent via the CLA is used as the canonical address
- for all contributors, the name used in https://www.openmicroscopy.org/teams/ or https://www.openmicroscopy.org/contributors/ is used as the canonical real name.

The .mailmap is constructed according to the official [documentation](https://git-scm.com/docs/gitmailmap) using one of the two forms:

```
Proper Name <proper@email.xx> <commit@email.xx>
```

for mapping different email addresses and

```
Proper Name <proper@email.xx> Commit Name <commit@email.xx>
```
for mapping different real names.

The unique list of commit authors can be generated and reviewing using `git shortlog -se`
See also https://github.com/ome/openmicroscopy/pull/6349, https://github.com/ome/bioformats/pull/4026, https://github.com/ome/omero-web/pull/482 and https://github.com/ome/omero-py/pull/375