### PR TITLE
Solution for delimiter reading issue (#210) utilizing dynamic checkpoints

### DIFF
--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -34,6 +34,7 @@ from omero.cmd import Delete2
 import sys
 import csv
 import copy
+from math import floor
 
 from omero.util.populate_roi import DownloadingOriginalFileProvider
 
@@ -158,28 +159,30 @@ def keyval_from_csv(conn, script_params):
         # Needs omero-py 5.9.1 or later
         temp_name = temp_file.name
         with open(temp_name, 'rt', encoding='utf-8-sig') as file_handle:
+            file_length = len(file_handle.read(-1))
             try:
                 delimiter = csv.Sniffer().sniff(
-                    file_handle.read(500), ",;\t").delimiter
+                    file_handle.read(floor(file_length/4)), ",;\t").delimiter
                 print("Using delimiter: ", delimiter,
-                      " after reading 500 characters")
+                    f" after reading {floor(file_length/4)} characters")
             except Exception:
                 file_handle.seek(0)
                 try:
                     delimiter = csv.Sniffer().sniff(
-                        file_handle.read(1000), ",;\t").delimiter
+                        file_handle.read(floor(file_length/2)), ",;\t").delimiter
                     print("Using delimiter: ", delimiter,
-                          " after reading 1000 characters")
+                        f" after reading {floor(file_length/2)} characters")
                 except Exception:
                     file_handle.seek(0)
                     try:
                         delimiter = csv.Sniffer().sniff(
-                            file_handle.read(2000), ";,\t").delimiter
+                            file_handle.read(floor(file_length*0.75)), ",;\t").delimiter
                         print("Using delimiter: ", delimiter,
-                              " after reading 2000 characters")
+                        f" after reading {floor(file_length*0.75)} characters")
                     except Exception:
                         print("Failed to sniff delimiter, using ','")
                         delimiter = ","
+
             # reset to start and read whole file...
             file_handle.seek(0)
             data = list(csv.reader(file_handle, delimiter=delimiter))

--- a/omero/annotation_scripts/KeyVal_from_csv.py
+++ b/omero/annotation_scripts/KeyVal_from_csv.py
@@ -158,27 +158,30 @@ def keyval_from_csv(conn, script_params):
         temp_file = provider.get_original_file_data(original_file)
         # Needs omero-py 5.9.1 or later
         temp_name = temp_file.name
+        file_length = original_file.size.val
         with open(temp_name, 'rt', encoding='utf-8-sig') as file_handle:
-            file_length = len(file_handle.read(-1))
             try:
                 delimiter = csv.Sniffer().sniff(
                     file_handle.read(floor(file_length/4)), ",;\t").delimiter
                 print("Using delimiter: ", delimiter,
-                    f" after reading {floor(file_length/4)} characters")
+                      f" after reading {floor(file_length/4)} characters")
             except Exception:
                 file_handle.seek(0)
                 try:
                     delimiter = csv.Sniffer().sniff(
-                        file_handle.read(floor(file_length/2)), ",;\t").delimiter
+                        file_handle.read(floor(file_length/2)),
+                        ",;\t").delimiter
                     print("Using delimiter: ", delimiter,
-                        f" after reading {floor(file_length/2)} characters")
+                          f"after reading {floor(file_length/2)} characters")
                 except Exception:
                     file_handle.seek(0)
                     try:
                         delimiter = csv.Sniffer().sniff(
-                            file_handle.read(floor(file_length*0.75)), ",;\t").delimiter
+                            file_handle.read(floor(file_length*0.75)),
+                            ",;\t").delimiter
                         print("Using delimiter: ", delimiter,
-                        f" after reading {floor(file_length*0.75)} characters")
+                              f" after reading {floor(file_length*0.75)}"
+                              " characters")
                     except Exception:
                         print("Failed to sniff delimiter, using ','")
                         delimiter = ","


### PR DESCRIPTION
Hello,

as detaild in #210 I implemented 3 dynamic checkpoints (at 25%/50%/75%) instead of fixed 500/1000/2000 characters.

I tried it with a fairly big .csv of 1.5 million characters and it worked as fast as the original solution.

I also tried around a bit with a smaller .csv with a lot of deletions and random other delimiters in between.
It performed reasonably well for such fringe cases, meaning it could not resolve the correct delimiter in 2 of 10 or so cases.

Please take a look and tell me what you think.
Thank you for your time!