### PR TITLE
don't attempt ROI stats on big images

### DIFF
--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -41,6 +41,12 @@ def log(data):
     print(data)
 
 
+def is_big_image(image):
+    """Return True if image is tiled."""
+    maxSize = image._conn.getMaxPlaneSize()
+    return (image.getSizeX() * image.getSizeY()) > (maxSize[0] * maxSize[1])
+
+
 def get_export_data(conn, script_params, image, units=None):
     """Get pixel data for shapes on image and returns list of dicts."""
     log("Image ID %s..." % image.id)
@@ -110,7 +116,7 @@ def get_export_data(conn, script_params, image, units=None):
             # get pixel intensities
             for z in z_indexes:
                 for t in t_indexes:
-                    if z is None or t is None:
+                    if z is None or t is None or is_big_image(image):
                         stats = None
                     else:
                         stats = roi_service.getShapeStatsRestricted(

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -43,8 +43,8 @@ def log(data):
 
 def is_big_image(image):
     """Return True if image is tiled."""
-    maxSize = image._conn.getMaxPlaneSize()
-    return (image.getSizeX() * image.getSizeY()) > (maxSize[0] * maxSize[1])
+    max_size = image._conn.getMaxPlaneSize()
+    return (image.getSizeX() * image.getSizeY()) > (max_size[0] * max_size[1])
 
 
 def get_export_data(conn, script_params, image, units=None):

--- a/omero/export_scripts/Batch_ROI_Export.py
+++ b/omero/export_scripts/Batch_ROI_Export.py
@@ -64,6 +64,7 @@ def get_export_data(conn, script_params, image, units=None):
     all_planes = script_params["Export_All_Planes"]
     include_points = script_params.get("Include_Points_Coords", False)
     size_c = image.getSizeC()
+    big_image = is_big_image(image)
     # Channels index
     channels = script_params.get("Channels", [1])
     ch_indexes = []
@@ -116,7 +117,7 @@ def get_export_data(conn, script_params, image, units=None):
             # get pixel intensities
             for z in z_indexes:
                 for t in t_indexes:
-                    if z is None or t is None or is_big_image(image):
+                    if z is None or t is None or big_image:
                         stats = None
                     else:
                         stats = roi_service.getShapeStatsRestricted(


### PR DESCRIPTION
If you try to run the `Batch_ROI_Export` script on Big images, it fails with:

```
> > serverStackTrace = ome.conditions.ApiUsageException: This method cannot handle tiled images yet. 
> > at ome.services.roi.GeomTool.getStatsRestricted(GeomTool.java:415) 
```

To avoid this, we first check for whether this is a big image and if so, we don't try to load stats.

To test, draw ROIs on a Big Image(s) and run Batch_ROI_Export script:

![Screenshot 2024-09-13 at 09 10 48](https://github.com/user-attachments/assets/edb75581-a71a-4d75-9fc1-efdbf509b55a)
