### PR TITLE
Adding support for custom user label

### DIFF
--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -499,22 +499,27 @@ def split_view_figure(conn, script_params):
     image_labels = []
 
     # function for getting image labels.
-    def get_image_names(full_name, tags_list, pd_list):
+    def get_image_names(full_name, tags_list, pd_list, iid):
         name = full_name.split("/")[-1]
         return [name]
 
     # default function for getting labels is getName (or use datasets / tags)
     if script_params["Image_Labels"] == "Datasets":
-        def get_datasets(name, tags_list, pd_list):
+        def get_datasets(name, tags_list, pd_list, iid):
             return [dataset for project, dataset in pd_list]
         get_labels = get_datasets
     elif script_params["Image_Labels"] == "Tags":
-        def get_tags(name, tags_list, pd_list):
+        def get_tags(name, tags_list, pd_list, iid):
             return [t for t in tags_list]
         get_labels = get_tags
     elif script_params["Image_Labels"] == "Custom":
-        def get_custom_label(name, tags_list, pd_list):
-            return [script_params["Custom_Label"]]
+        def get_custom_label(name, tags_list, pd_list, iid):
+            all_labels = script_params["All_labels"]
+            for label_pair in all_labels.split("$"):
+                if str(iid) in label_pair:
+                    if len(label_pair.split(":")) > 1:
+                        return [label_pair.split(":")[1]]
+            return [""]
         get_labels = get_custom_label
     else:
         get_labels = get_image_names
@@ -556,7 +561,7 @@ def split_view_figure(conn, script_params):
         log("  Tags: %s" % tags)
         log("  Project/Datasets: %s" % pd_string)
 
-        image_labels.append(get_labels(name, tags_list, pd_list))
+        image_labels.append(get_labels(name, tags_list, pd_list, iid))
 
     # use the first image to define dimensions, channel colours etc.
     size_x = omero_image.getSizeX()
@@ -755,7 +760,7 @@ See http://help.openmicroscopy.org/publish.html#figures""",
             " or tags", values=labels, default='Image Name'),
 
         scripts.String(
-            "Custom_Label", grouping="93",
+            "All_labels", grouping="93",
             description="User defined label", default=''),
 
         scripts.Int(

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -515,10 +515,10 @@ def split_view_figure(conn, script_params):
     elif script_params["Image_Labels"] == "Custom":
         def get_custom_label(name, tags_list, pd_list, iid):
             all_labels = script_params["All_labels"]
-            for label_pair in all_labels.split("$"):
+            for label_pair in all_labels.split("//n"):
                 if str(iid) in label_pair:
-                    if len(label_pair.split(":")) > 1:
-                        return [label_pair.split(":")[1]]
+                    if len(label_pair.split("//s")) > 1:
+                        return [label_pair.split("//s")[1]]
             return [""]
         get_labels = get_custom_label
     else:

--- a/omero/figure_scripts/Split_View_Figure.py
+++ b/omero/figure_scripts/Split_View_Figure.py
@@ -683,7 +683,8 @@ def run_script():
     """
 
     data_types = [rstring('Image')]
-    labels = [rstring('Image Name'), rstring('Datasets'), rstring('Tags'), rstring('Custom')]
+    labels = [rstring('Image Name'), rstring('Datasets'), rstring('Tags'),
+              rstring('Custom')]
     algorithms = [rstring('Maximum Intensity'), rstring('Mean Intensity')]
     formats = [rstring('JPEG'), rstring('PNG'), rstring('TIFF')]
     ckeys = list(COLOURS.keys())


### PR DESCRIPTION
Hello @knabar, @will-moore 

PR linked to https://github.com/ome/omero-web/pull/639

Small contribution on Split_View_Figure plugin, asked by one of our users. I added support to enter a custom label, which enable users to also not put any labels.


![Split_View_Figure(6)](https://github.com/user-attachments/assets/ee604719-409d-4165-9556-63f5543eda49)
